### PR TITLE
Fix https://github.com/gavv/httpexpect/issues/26

### DIFF
--- a/example/echo.go
+++ b/example/echo.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package example
 
 import (

--- a/example/echo_test.go
+++ b/example/echo_test.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package example
 
 import (

--- a/example/example.go
+++ b/example/example.go
@@ -1,4 +1,2 @@
-// +build ignore
-
 // Package example is usage example for httpexpect.
 package example

--- a/example/example.go
+++ b/example/example.go
@@ -1,2 +1,4 @@
+// +build ignore
+
 // Package example is usage example for httpexpect.
 package example

--- a/example/fruits.go
+++ b/example/fruits.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package example
 
 import (

--- a/example/fruits_test.go
+++ b/example/fruits_test.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package example
 
 import (

--- a/example/iris.go
+++ b/example/iris.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package example
 
 import (

--- a/example/iris_test.go
+++ b/example/iris_test.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package example
 
 import (


### PR DESCRIPTION
Prevent example dependencies from being vendored along side github.com/gavv/httpexpect