### PR TITLE
Add Google App Engine Testing Instance support (with RequestFactory interface{})

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Workflow:
 * URL query parameters (encoding using [`go-querystring`](https://github.com/google/go-querystring) package).
 * Headers, cookies, payload: JSON,  urlencoded or multipart forms (encoding using [`form`](https://github.com/ajg/form) package), plain text.
 * Create custom [request builders](#reusable-builders) that can be reused.
+* Create requests for Google App Engine testing with `RequestFactory`.
 
 ##### Response assertions
 

--- a/_examples/gae_test.go
+++ b/_examples/gae_test.go
@@ -1,0 +1,67 @@
+package examples
+
+import (
+	"github.com/gavv/httpexpect"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/aetest"
+	"net/http"
+	"os"
+	"testing"
+)
+
+// init is used by GAE to start serving the app
+// added here for illustration purposes
+// func init() {
+// 	http.Handle("/", Router())
+// }
+
+func Router() http.Handler {
+	m := http.NewServeMux()
+
+	m.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		_ = appengine.NewContext(r)
+		w.Write([]byte("pong"))
+	})
+
+	return m
+}
+
+// GaeInstance is our global dev_appserver instance
+var GaeInstance aetest.Instance
+
+// TestMain is called first to create the GaeInstance
+func TestMain(m *testing.M) {
+
+	// INFO: Remove the return to actually run the tests.
+	// Requires installed Google Appengine SDK.
+	// https://cloud.google.com/appengine/downloads
+	return
+
+	var err error
+	GaeInstance, err = aetest.NewInstance(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	c := m.Run() // call all actual tests
+	GaeInstance.Close()
+	os.Exit(c)
+}
+
+// newHttpExpect returns a new Expect instance for testing
+func newHttpExpect(t *testing.T) *httpexpect.Expect {
+	return httpexpect.WithConfig(httpexpect.Config{
+		Client: &http.Client{
+			Transport: httpexpect.NewBinder(Router()),
+			Jar:       httpexpect.NewJar(),
+		},
+		Reporter:       httpexpect.NewAssertReporter(t),
+		RequestFactory: GaeInstance,
+	})
+}
+
+// TestPing is an actual tests, using the global GaeInstance
+func TestPing(t *testing.T) {
+	e := newHttpExpect(t)
+	e.GET("/ping").Expect().Status(200)
+}

--- a/expect.go
+++ b/expect.go
@@ -66,6 +66,7 @@
 package httpexpect
 
 import (
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"time"
@@ -111,6 +112,10 @@ type Config struct {
 	// you're happy with their format, but want to send logs somewhere
 	// else instead of testing.TB.
 	Printers []Printer
+
+	// RequestFactory is used to pass in a custom *http.Request generation func.
+	// Useful for Google App Engine testing for example. May be nil.
+	RequestFactory RequestFactory
 }
 
 // Client is used to send http.Request and receive http.Response.
@@ -150,6 +155,12 @@ type Reporter interface {
 type LoggerReporter interface {
 	Logger
 	Reporter
+}
+
+// RequestFactory can be used for custom http requests
+// i.e. Google App Engine test http requests
+type RequestFactory interface {
+	NewRequest(method, urlStr string, body io.Reader) (*http.Request, error)
 }
 
 // New returns a new Expect object.

--- a/request_test.go
+++ b/request_test.go
@@ -29,6 +29,7 @@ func TestRequestFailed(t *testing.T) {
 	req := &Request{
 		config: config,
 		chain:  chain,
+		http:   &http.Request{},
 	}
 
 	resp := req.Expect()


### PR DESCRIPTION
This PR adds support for Google App Engine Testing.

#### Background
Each `*http.Request` needs to be registered with the GAE test instance. Otherwise calls to `appengine.NewContext(*http.Request)` will panic with:

```
appengine: NewContext passed an unknown http.Request
```

#### References
* https://github.com/golang/appengine/blob/master/aetest/instance_vm.go#L60
* https://cloud.google.com/appengine/docs/go/tools/localunittesting/

#### Changes

* Add `GaeTestInstance` to `struct Config`
* If `Config.GaeTestInstance` is specified (not nil), use `GaeTestInstance.NewRequest` to create `*http.Request` that is associated with the GAE test instance.
* Otherwise create plain `*http.Request`.
* In order to keep the correct reference, `struct Request` needs pointer to request.

