### PR TITLE
Update travis for go 1.8 - read description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 
 go:
-    - 1.7
+    - 1.8
 
 before_install:
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
@gavv Most of the web frameworks (first Iris) uses explicity the http.Pusher interface, we need go 1.8 because we can't use the *http.PushOptions on go 1.7 too.  So I **removed** the go 1.7, if you don't agree with that just let it as it is*