### PR TITLE
WIP: Basic WebSocket support

### DIFF
--- a/_examples/websocket.go
+++ b/_examples/websocket.go
@@ -1,0 +1,27 @@
+package examples
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+// WsHandler is a simple http.Handler that implements WebSocket echo server.
+func WsHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader := &websocket.Upgrader{}
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer c.Close()
+	for {
+		mt, message, err := c.ReadMessage()
+		if err != nil {
+			break
+		}
+		err = c.WriteMessage(mt, message)
+		if err != nil {
+			break
+		}
+	}
+}

--- a/_examples/websocket.go
+++ b/_examples/websocket.go
@@ -4,10 +4,13 @@ import (
 	"net/http"
 
 	"github.com/gorilla/websocket"
+
+	fastws "github.com/fasthttp-contrib/websocket"
+	"github.com/valyala/fasthttp"
 )
 
-// WsHandler is a simple http.Handler that implements WebSocket echo server.
-func WsHandler(w http.ResponseWriter, r *http.Request) {
+// WsHttpHandler is a simple http.Handler that implements WebSocket echo server.
+func WsHttpHandler(w http.ResponseWriter, r *http.Request) {
 	upgrader := &websocket.Upgrader{}
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -23,5 +26,27 @@ func WsHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			break
 		}
+	}
+}
+
+// WsFastHandler is a simple fasthttp.RequestHandler that implements
+// WebSocket echo server.
+func WsFastHandler(ctx *fasthttp.RequestCtx) {
+	upgrader := fastws.New(func (c *fastws.Conn) {
+		defer c.Close()
+		for {
+			mt, message, err := c.ReadMessage()
+			if err != nil {
+				break
+			}
+			err = c.WriteMessage(mt, message)
+			if err != nil {
+				break
+			}
+		}
+	})
+	err := upgrader.Upgrade(ctx)
+	if err != nil {
+		panic(err)
 	}
 }

--- a/_examples/websocket_test.go
+++ b/_examples/websocket_test.go
@@ -1,0 +1,56 @@
+package examples
+
+import (
+	"testing"
+	"net/http"
+
+	"github.com/gavv/httpexpect"
+	"git.instrumentisto.com/streaming/api/_cache/dep/sources/https---github.com-gorilla-websocket"
+)
+
+func wsTester(t *testing.T) *httpexpect.Expect {
+	return httpexpect.WithConfig(httpexpect.Config{
+		BaseURL: "http://example.com",
+		Dialer: httpexpect.NewBinder(http.HandlerFunc(WsHandler)).Dialer(),
+		Reporter: httpexpect.NewAssertReporter(t),
+		Printers: []httpexpect.Printer{
+			httpexpect.NewDebugPrinter(t, true),
+		},
+	})
+}
+
+func TestWsHandler_Text(t *testing.T) {
+	conn := wsTester(t).WS("/ws").Expect().
+		Status(http.StatusSwitchingProtocols).
+		Connection()
+	defer conn.Disconnect()
+
+	conn.WriteText("hi").
+		Expect().Text().Body().Equal("hi")
+}
+
+func TestWsHandler_JSON(t *testing.T) {
+	conn := wsTester(t).WS("/ws").Expect().
+		Status(http.StatusSwitchingProtocols).
+		Connection()
+	defer conn.Disconnect()
+
+	conn.WriteJSON(struct {
+		Message string `json:"message"`
+	}{"hi"}).
+		Expect().
+		Text().JSON().Object().ValueEqual("message", "hi")
+}
+
+func TestWsHandler_Close(t *testing.T) {
+	conn := wsTester(t).WS("/ws").Expect().
+		Status(http.StatusSwitchingProtocols).
+		Connection()
+	defer conn.Disconnect()
+
+	conn.WriteMessage(websocket.CloseMessage,
+		[]byte("Namárië..."), websocket.CloseGoingAway)
+	conn.Expect().
+		Closed().
+		NoContent()
+}

--- a/expect.go
+++ b/expect.go
@@ -182,6 +182,18 @@ type Printer interface {
 	Response(*http.Response, time.Duration)
 }
 
+// WsPrinter is used to print writes and reads of WebSocket connection.
+// DebugPrinter implements this interface.
+type WsPrinter interface {
+	Printer
+
+	// Write is called before writes to WebSocket connection.
+	Write(typ int, content []byte, closeCode int)
+
+	// Read is called after reads from WebSocket connection.
+	Read(typ int, content []byte, closeCode int)
+}
+
 // Logger is used as output backend for Printer.
 // testing.TB implements this interface.
 type Logger interface {

--- a/expect.go
+++ b/expect.go
@@ -260,7 +260,7 @@ func New(t LoggerReporter, baseURL string) *Expect {
 // If Dialer is nil, it's set to a default dialer with handshake timeout 45s
 // and enabled compression:
 //  &websocket.Dialer{
-//      HandshakeTimeout:  45 * time.Second,
+//      HandshakeTimeout:  DefaultWsConnectionTimeout,
 //      EnableCompression: true,
 //  }
 //
@@ -297,7 +297,7 @@ func WithConfig(config Config) *Expect {
 	}
 	if config.Dialer == nil {
 		config.Dialer = &websocket.Dialer{
-			HandshakeTimeout:  45 * time.Second,
+			HandshakeTimeout:  DefaultWsConnectionTimeout,
 			EnableCompression: true,
 		}
 	}

--- a/expect.go
+++ b/expect.go
@@ -137,7 +137,17 @@ type RequestFactory interface {
 }
 
 // Client is used to send http.Request and receive http.Response.
-// http.Client, Binder, and FastBinder implement this interface.
+// http.Client implements this interface.
+//
+// Binder and FastBinder may be used to obtain this interface implementation.
+//
+// Example:
+//  httpBinderClient := &http.Client{
+//    Transport: httpexpect.NewBinder(HTTPHandler),
+//  }
+//  fastBinderClient := &http.Client{
+//    Transport: httpexpect.NewFastBinder(FastHTTPHandler),
+//  }
 type Client interface {
 	// Do sends request and returns response.
 	Do(*http.Request) (*http.Response, error)
@@ -146,6 +156,16 @@ type Client interface {
 // Dialer is used to establish websocket.Conn and receive http.Response
 // of handshake result.
 // websocket.Dialer implements this interface.
+//
+// Binder and FastBinder may be used to obtain this interface implementation.
+//
+// Example:
+//  httpBinderClient := &http.Client{
+//    Dialer: httpexpect.NewBinder(HTTPHandler).Dialer(),
+//  }
+//  fastBinderClient := &http.Client{
+//    Dialer: httpexpect.NewFastBinder(FastHTTPHandler).Dialer(),
+//  }
 type Dialer interface {
 	// Dial establishes new WebSocket connection and returns response
 	// of handshake result.

--- a/request.go
+++ b/request.go
@@ -907,6 +907,7 @@ func (r *Request) Expect() *Response {
 	resp, conn, elapsed := r.sendRequest()
 
 	if r.isWs {
+		conn := &wsConn{conn, r.config}
 		return makeWsResponse(r.chain, conn, resp, elapsed)
 	}
 	return makeResponse(r.chain, resp, elapsed)

--- a/response.go
+++ b/response.go
@@ -286,7 +286,7 @@ func (r *Response) Cookie(name string) *Cookie {
 // Example:
 //  resp := req.Expect()
 //  conn := resp.Connection()
-//  defer conn.Close()
+//  defer conn.Disconnect()
 func (r *Response) Connection() *WsConnection {
 	switch {
 	case !r.isWs:

--- a/response.go
+++ b/response.go
@@ -44,7 +44,7 @@ type Response struct {
 	content []byte
 	cookies []*http.Cookie
 	time    time.Duration
-	isWS    bool
+	isWs    bool
 }
 
 // NewResponse returns a new Response given a reporter used to report
@@ -85,12 +85,12 @@ func makeResponse(
 	}
 }
 
-func makeResponseWS(
+func makeWsResponse(
 	chain chain, conn *websocket.Conn, response *http.Response,
 	duration time.Duration,
 ) *Response {
 	resp := makeResponse(chain, response, duration)
-	resp.isWS = true
+	resp.isWs = true
 	resp.conn = conn
 	return resp
 }
@@ -283,16 +283,16 @@ func (r *Response) Cookie(name string) *Cookie {
 //
 // Example:
 //  TODO
-func (r *Response) Connection() *Connection {
+func (r *Response) Connection() *WsConnection {
 	switch {
-	case !r.isWS:
+	case !r.isWs:
 		r.chain.fail("\nunexpected Connection usage for non-WebSocket response")
 	case r.conn == nil:
 		r.chain.fail(
-			"\nexpected successful WebSocket connection, "+
+			"\nexpected successful WebSocket connection, " +
 				"but got handshake failure")
 	}
-	return makeConnection(r.chain, r.conn)
+	return makeWsConnection(r.chain, r.conn)
 }
 
 // Body returns a new String object that may be used to inspect response body.

--- a/response.go
+++ b/response.go
@@ -278,11 +278,15 @@ func (r *Response) Cookie(name string) *Cookie {
 	return &Cookie{r.chain, nil}
 }
 
-// Connection returns WebSocket Connection that may be used to interact with
+// Connection returns WsConnection that may be used to interact with
 // WebSocket server.
 //
+// That is responsibility of caller to explicitly close WsConnection after use.
+//
 // Example:
-//  TODO
+//  resp := req.Expect()
+//  conn := resp.Connection()
+//  defer conn.Close()
 func (r *Response) Connection() *WsConnection {
 	switch {
 	case !r.isWs:

--- a/response.go
+++ b/response.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/ajg/form"
-	"github.com/gorilla/websocket"
 )
 
 // StatusRange is enum for response status ranges.
@@ -40,7 +39,7 @@ const (
 type Response struct {
 	chain   chain
 	resp    *http.Response
-	conn    *websocket.Conn
+	conn    *wsConn
 	content []byte
 	cookies []*http.Cookie
 	time    time.Duration
@@ -86,7 +85,7 @@ func makeResponse(
 }
 
 func makeWsResponse(
-	chain chain, conn *websocket.Conn, response *http.Response,
+	chain chain, conn *wsConn, response *http.Response,
 	duration time.Duration,
 ) *Response {
 	resp := makeResponse(chain, response, duration)

--- a/response_test.go
+++ b/response_test.go
@@ -16,7 +16,7 @@ func TestResponseFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	resp := &Response{chain, nil, nil, nil, 0}
+	resp := &Response{chain, nil, nil, nil, nil, 0, false}
 
 	resp.chain.assertFailed(t)
 

--- a/ws_connection.go
+++ b/ws_connection.go
@@ -1,0 +1,78 @@
+package httpexpect
+
+import (
+	"github.com/gorilla/websocket"
+	"time"
+)
+
+type WsConnection struct {
+	chain  chain
+	conn   *websocket.Conn
+	closed bool
+}
+
+func NewWsConnection(reporter Reporter, conn *websocket.Conn) *WsConnection {
+	return makeWsConnection(makeChain(reporter), conn)
+}
+
+func makeWsConnection(chain chain, conn *websocket.Conn) *WsConnection {
+	return &WsConnection{
+		chain: chain,
+		conn:  conn,
+	}
+}
+
+func (c *WsConnection) Close() {
+	if c.conn == nil || c.closed {
+		return
+	}
+
+	// Cleanly close the connection by sending a close message and then
+	// waiting (with timeout) for the server to close the connection.
+	c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	err := c.conn.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	if err != nil {
+		return
+	}
+	c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	c.conn.ReadMessage() // nolint: errcheck
+}
+
+// Raw returns underlying websocket.Conn object.
+// This is the value originally passed to NewConnection.
+func (c *WsConnection) Raw() *websocket.Conn {
+	return c.conn
+}
+
+func (c *WsConnection) Expect() (m *WsMessage) {
+	m = &WsMessage{
+		chain: c.chain,
+	}
+	switch {
+	case c.chain.failed():
+		return
+	case c.conn == nil:
+		c.chain.fail("\nunexpected read failed WebSocket connection")
+		return
+	case c.closed:
+		c.chain.fail("\nunexpected read closed WebSocket connection")
+		return
+	}
+	var err error
+	// TODO: deadline???
+	// TODO: correct Read ping message?
+	m.typ, m.body, err = c.conn.ReadMessage()
+	if err != nil {
+		if cls, ok := err.(*websocket.CloseError); ok {
+			m.closeCode = cls.Code
+			m.body = []byte(cls.Text)
+		} else {
+			c.chain.fail(
+				"\nexpected read WebSocket connection, "+
+					"but got failure: %s", err.Error())
+			return
+		}
+	}
+	return
+}

--- a/ws_connection.go
+++ b/ws_connection.go
@@ -87,12 +87,12 @@ func (c *WsConnection) Expect() (m *WsMessage) {
 		return
 	}
 	var err error
-	m.typ, m.body, err = c.conn.ReadMessage()
+	m.typ, m.content, err = c.conn.ReadMessage()
 	if err != nil {
 		if cls, ok := err.(*websocket.CloseError); ok {
 			m.typ = websocket.CloseMessage
 			m.closeCode = cls.Code
-			m.body = []byte(cls.Text)
+			m.content = []byte(cls.Text)
 		} else {
 			c.chain.fail(
 				"\nexpected read WebSocket connection, "+

--- a/ws_connection.go
+++ b/ws_connection.go
@@ -382,7 +382,7 @@ func (c *WsConnection) WriteBytes(b []byte) *WsConnection {
 	return c.WriteMessage(websocket.TextMessage, b)
 }
 
-// WriteBytes is a shorthand for c.WriteMessage(websocket.BinaryMessage, b).
+// WriteBinary is a shorthand for c.WriteMessage(websocket.BinaryMessage, b).
 func (c *WsConnection) WriteBinary(b []byte) *WsConnection {
 	if c.checkUnusable("WriteBinary") {
 		return c

--- a/ws_message.go
+++ b/ws_message.go
@@ -2,197 +2,285 @@ package httpexpect
 
 import (
 	"encoding/json"
+
 	"github.com/gorilla/websocket"
 )
 
-type (
-	WsMessage struct {
-		chain     chain
-		typ       int
-		body      []byte
-		closeCode int
-	}
-
-	WsTextMessage struct {
-		msg *WsMessage
-	}
-
-	WsBinaryMessage struct {
-		msg *WsMessage
-	}
-
-	WsCloseMessage struct {
-		msg *WsMessage
-	}
-)
-
-func (m *WsMessage) Message() (msg *WsTextMessage) {
-	msg = &WsTextMessage{msg: m}
-	switch {
-	case m.chain.failed():
-		return
-	case m.typ != websocket.TextMessage:
-		m.chain.fail(
-			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
-			wsMessageTypeName(websocket.TextMessage),
-			wsMessageTypeName(m.typ))
-		return
-	}
-	return
+// WsMessage provides methods to inspect message read from WebSocket connection.
+type WsMessage struct {
+	chain     chain
+	typ       int
+	content   []byte
+	closeCode int
 }
 
-func (m *WsMessage) Binary() (msg *WsBinaryMessage) {
-	msg = &WsBinaryMessage{msg: m}
-	switch {
-	case m.chain.failed():
-		return
-	case m.typ != websocket.BinaryMessage:
-		m.chain.fail(
-			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
-			wsMessageTypeName(websocket.BinaryMessage),
-			wsMessageTypeName(m.typ))
-		return
-	}
-	return
+// Closed is a shorthand for m.Type(websocket.CloseMessage).
+func (m *WsMessage) Closed() *WsMessage {
+	return m.Type(websocket.CloseMessage)
 }
 
-func (m *WsMessage) Closed() (msg *WsCloseMessage) {
-	msg = &WsCloseMessage{msg: m}
-	switch {
-	case m.chain.failed():
-		return
-	case m.typ != websocket.CloseMessage:
-		m.chain.fail(
-			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
-			wsMessageTypeName(websocket.CloseMessage),
-			wsMessageTypeName(m.typ))
-		return
-	}
-	return
+// NotClosed is a shorthand for m.NotType(websocket.CloseMessage).
+func (m *WsMessage) NotClosed() *WsMessage {
+	return m.NotType(websocket.CloseMessage)
 }
 
-func (m *WsMessage) Body() *String {
-	return &String{m.chain, string(m.body)}
+// Binary is a shorthand for m.Type(websocket.BinaryMessage).
+func (m *WsMessage) Binary() *WsMessage {
+	return m.Type(websocket.BinaryMessage)
 }
 
-func (m *WsMessage) JSON() *Value {
-	return &Value{m.chain, m.getJSON()}
+// NotBinary is a shorthand for m.NotType(websocket.BinaryMessage).
+func (m *WsMessage) NotBinary() *WsMessage {
+	return m.NotType(websocket.BinaryMessage)
 }
 
-func (m *WsMessage) NoContent() *WsMessage {
+// Text is a shorthand for m.Type(websocket.TextMessage).
+func (m *WsMessage) Text() *WsMessage {
+	return m.Type(websocket.TextMessage)
+}
+
+// NotText is a shorthand for m.NotType(websocket.TextMessage).
+func (m *WsMessage) NotText() *WsMessage {
+	return m.NotType(websocket.TextMessage)
+}
+
+// Type succeeds if WebSocket message type is one of the given.
+//
+// WebSocket message types are defined in RFC 6455, section 11.8.
+//
+// See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
+//
+// Example:
+//  msg := conn.Expect()
+//  msg.Type(websocket.TextMessage, websocket.BinaryMessage)
+func (m *WsMessage) Type(typ ...int) *WsMessage {
 	switch {
 	case m.chain.failed():
 		return m
-	case len(m.body) == 0:
-		return m
-	}
-	switch m.typ {
-	case websocket.BinaryMessage:
-		m.chain.fail(
-			"\nexpected message body being empty, but got:\n%d bytes",
-			len(m.body))
-	default:
-		m.chain.fail(
-			"\nexpected message body being empty, but got:\n%s",
-			string(m.body))
-	}
-	return m
-}
-
-func (m *WsMessage) Raw() (typ int, body []byte, closeCode int) {
-	return m.typ, m.body, m.closeCode
-}
-
-func (m *WsTextMessage) Body() *String {
-	return m.msg.Body()
-}
-
-func (m *WsTextMessage) JSON() *Value {
-	return m.msg.JSON()
-}
-
-func (m *WsTextMessage) NoContent() *WsTextMessage {
-	m.msg.NoContent()
-	return m
-}
-
-func (m *WsTextMessage) Raw() string {
-	return string(m.msg.body)
-}
-
-func (m *WsBinaryMessage) Body() *Value {
-	return &Value{m.msg.chain, m.msg.body}
-}
-
-func (m *WsBinaryMessage) NoContent() *WsBinaryMessage {
-	m.msg.NoContent()
-	return m
-}
-
-func (m *WsBinaryMessage) Raw() []byte {
-	return m.msg.body
-}
-
-func (m *WsCloseMessage) Code(code ...int) *WsCloseMessage {
-	switch {
-	case m.msg.chain.failed():
-		return m
-	case len(code) == 0:
-		m.msg.chain.fail("\nunexpected nil argument passed to Code")
+	case len(typ) == 0:
+		m.chain.fail("\nunexpected nil argument passed to Type")
 		return m
 	}
 	yes := false
-	for _, c := range code {
-		if c == m.msg.closeCode {
+	for _, t := range typ {
+		if t == m.typ {
 			yes = true
 			break
 		}
 	}
 	if !yes {
-		m.msg.chain.fail(
-			"\nexpected close code equal to one of:\n%v\n\nbut got:\n%d",
-			code, m.msg.closeCode)
+		if len(typ) > 1 {
+			m.chain.fail(
+				"\nexpected message type equal to one of:\n %v\n\nbut got:\n %d",
+				typ, m.typ)
+		} else {
+			m.chain.fail(
+				"\nexpected message type:\n %d\n\nbut got:\n %d",
+				typ[0], m.typ)
+		}
 	}
 	return m
 }
 
-func (m *WsCloseMessage) CodeNotEqual(code ...int) *WsCloseMessage {
+// NotType succeeds if WebSocket message type is none of the given.
+//
+// WebSocket message types are defined in RFC 6455, section 11.8.
+//
+// See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
+//
+// Example:
+//  msg := conn.Expect()
+//  msg.NotType(websocket.CloseMessage, websocket.BinaryMessage)
+func (m *WsMessage) NotType(typ ...int) *WsMessage {
 	switch {
-	case m.msg.chain.failed():
+	case m.chain.failed():
 		return m
-	case len(code) == 0:
-		m.msg.chain.fail("\nunexpected nil argument passed to CodeNotEqual")
+	case len(typ) == 0:
+		m.chain.fail("\nunexpected nil argument passed to NotType")
 		return m
 	}
-	for _, c := range code {
-		if c == m.msg.closeCode {
-			m.msg.chain.fail(
-				"\nexpected close code not equal:\n%v\n\nbut got:\n%d",
-				code, m.msg.closeCode)
+	for _, t := range typ {
+		if t == m.typ {
+			if len(typ) > 1 {
+				m.chain.fail(
+					"\nexpected message type not equal:\n %v\n\nbut got:\n %d",
+					typ, m.typ)
+			} else {
+				m.chain.fail(
+					"\nexpected message type not equal:\n %d\n\nbut it did",
+					typ[0], m.typ)
+			}
 			return m
 		}
 	}
 	return m
 }
 
-func (m *WsCloseMessage) Body() *String {
-	return m.msg.Body()
-}
-
-func (m *WsCloseMessage) JSON() *Value {
-	return m.msg.JSON()
-}
-
-func (m *WsCloseMessage) NoContent() *WsCloseMessage {
-	m.msg.NoContent()
+// Code succeeds if WebSocket close code is one of the given.
+//
+// Code fails if WebSocket message type is not "8 - Connection Close Frame".
+//
+// WebSocket close codes are defined in RFC 6455, section 11.7.
+//
+// See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
+//
+// Example:
+//  msg := conn.Expect().Closed()
+//  msg.Code(websocket.CloseNormalClosure, websocket.CloseGoingAway)
+func (m *WsMessage) Code(code ...int) *WsMessage {
+	switch {
+	case m.chain.failed():
+		return m
+	case len(code) == 0:
+		m.chain.fail("\nunexpected nil argument passed to Code")
+		return m
+	case m.checkClosed("Code"):
+		return m
+	}
+	yes := false
+	for _, c := range code {
+		if c == m.closeCode {
+			yes = true
+			break
+		}
+	}
+	if !yes {
+		if len(code) > 1 {
+			m.chain.fail(
+				"\nexpected close code equal to one of:\n %v\n\nbut got:\n %d",
+				code, m.closeCode)
+		} else {
+			m.chain.fail(
+				"\nexpected close code:\n %d\n\nbut got:\n %d",
+				code[0], m.closeCode)
+		}
+	}
 	return m
 }
 
-func (m *WsCloseMessage) Raw() *websocket.CloseError {
-	return &websocket.CloseError{
-		Code: m.msg.closeCode,
-		Text: string(m.msg.body),
+// NotCode succeeds if WebSocket close code is none of the given.
+//
+// NotCode fails if WebSocket message type is not "8 - Connection Close Frame".
+//
+// WebSocket close codes are defined in RFC 6455, section 11.7.
+//
+// See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
+//
+// Example:
+//  msg := conn.Expect().Closed()
+//  msg.NotCode(websocket.CloseAbnormalClosure, websocket.CloseNoStatusReceived)
+func (m *WsMessage) NotCode(code ...int) *WsMessage {
+	switch {
+	case m.chain.failed():
+		return m
+	case len(code) == 0:
+		m.chain.fail("\nunexpected nil argument passed to CodeNotEqual")
+		return m
+	case m.checkClosed("CodeNotEqual"):
+		return m
 	}
+	for _, c := range code {
+		if c == m.closeCode {
+			if len(code) > 1 {
+				m.chain.fail(
+					"\nexpected close code not equal:\n %v\n\nbut got:\n %d",
+					code, m.closeCode)
+			} else {
+				m.chain.fail(
+					"\nexpected close code not equal:\n %d\n\nbut it did",
+					code[0], m.closeCode)
+			}
+			return m
+		}
+	}
+	return m
+}
+
+func (m *WsMessage) checkClosed(where string) bool {
+	if m.typ != websocket.CloseMessage {
+		m.chain.fail(
+			"\nunexpected %s usage for not '%' WebSocket message type\n\n"+
+				"got type:\n %s",
+			where,
+			wsMessageTypeName(websocket.CloseMessage),
+			wsMessageTypeName(m.typ))
+		return true
+	}
+	return false
+}
+
+// Raw returns underlying type, content and close code of WebSocket message.
+// Theses values are originally read from WebSocket connection.
+func (m *WsMessage) Raw() (typ int, content []byte, closeCode int) {
+	return m.typ, m.content, m.closeCode
+}
+
+// Body returns a new String object that may be used to inspect
+// WebSocket message content.
+//
+// Example:
+//  msg := conn.Expect()
+//  msg.Body().NotEmpty()
+//  msg.Body().Length().Equal(100)
+func (m *WsMessage) Body() *String {
+	return &String{m.chain, string(m.content)}
+}
+
+// Content returns a new Value object that may be used to inspect
+// WebSocket message content.
+//
+// Example:
+//  msg := conn.Expect()
+//  msg.Content().Equal([]byte{0, 1, 2})
+func (m *WsMessage) Content() *Value {
+	return &Value{m.chain, m.content}
+}
+
+// NoContent succeeds if WebSocket message has no content (is empty).
+func (m *WsMessage) NoContent() *WsMessage {
+	switch {
+	case m.chain.failed():
+		return m
+	case len(m.content) == 0:
+		return m
+	}
+	switch m.typ {
+	case websocket.BinaryMessage:
+		m.chain.fail(
+			"\nexpected message body being empty, but got:\n %d bytes",
+			len(m.content))
+	default:
+		m.chain.fail(
+			"\nexpected message body being empty, but got:\n %s",
+			string(m.content))
+	}
+	return m
+}
+
+// JSON returns a new Value object that may be used to inspect JSON contents
+// of WebSocket message.
+//
+// JSON succeeds if JSON may be decoded from message content.
+//
+// Example:
+//  msg := conn.Expect()
+//  msg.JSON().Array().Elements("foo", "bar")
+func (m *WsMessage) JSON() *Value {
+	return &Value{m.chain, m.getJSON()}
+}
+
+func (m *WsMessage) getJSON() interface{} {
+	if m.chain.failed() {
+		return nil
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(m.content, &value); err != nil {
+		m.chain.fail(err.Error())
+		return nil
+	}
+
+	return value
 }
 
 func wsMessageTypeName(typ int) string {
@@ -209,18 +297,4 @@ func wsMessageTypeName(typ int) string {
 		return "pong"
 	}
 	return "unknown"
-}
-
-func (m *WsMessage) getJSON() interface{} {
-	if m.chain.failed() {
-		return nil
-	}
-
-	var value interface{}
-	if err := json.Unmarshal(m.body, &value); err != nil {
-		m.chain.fail(err.Error())
-		return nil
-	}
-
-	return value
 }

--- a/ws_message.go
+++ b/ws_message.go
@@ -47,7 +47,6 @@ func (m *WsMessage) NotText() *WsMessage {
 // Type succeeds if WebSocket message type is one of the given.
 //
 // WebSocket message types are defined in RFC 6455, section 11.8.
-//
 // See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
 //
 // Example:
@@ -85,7 +84,6 @@ func (m *WsMessage) Type(typ ...int) *WsMessage {
 // NotType succeeds if WebSocket message type is none of the given.
 //
 // WebSocket message types are defined in RFC 6455, section 11.8.
-//
 // See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
 //
 // Example:
@@ -121,7 +119,6 @@ func (m *WsMessage) NotType(typ ...int) *WsMessage {
 // Code fails if WebSocket message type is not "8 - Connection Close Frame".
 //
 // WebSocket close codes are defined in RFC 6455, section 11.7.
-//
 // See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
 //
 // Example:
@@ -163,7 +160,6 @@ func (m *WsMessage) Code(code ...int) *WsMessage {
 // NotCode fails if WebSocket message type is not "8 - Connection Close Frame".
 //
 // WebSocket close codes are defined in RFC 6455, section 11.7.
-//
 // See also https://godoc.org/github.com/gorilla/websocket#pkg-constants
 //
 // Example:

--- a/ws_message.go
+++ b/ws_message.go
@@ -1,0 +1,208 @@
+package httpexpect
+
+import (
+	"encoding/json"
+	"github.com/gorilla/websocket"
+)
+
+type (
+	WsMessage struct {
+		chain     chain
+		typ       int
+		body      []byte
+		closeCode int
+	}
+
+	WsTextMessage struct {
+		msg *WsMessage
+	}
+
+	WsBinaryMessage struct {
+		msg *WsMessage
+	}
+
+	WsCloseMessage struct {
+		msg *WsMessage
+	}
+
+	// TODO: impl
+	WsPingMessage struct {
+		msg *WsMessage
+	}
+
+	WsPongMessage struct {
+		msg *WsMessage
+	}
+)
+
+func (m *WsMessage) Message() (msg *WsTextMessage) {
+	msg = &WsTextMessage{msg: m}
+	switch {
+	case m.chain.failed():
+		return
+	case m.typ != websocket.TextMessage:
+		m.chain.fail(
+			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
+			wsMessageTypeName(websocket.TextMessage),
+			wsMessageTypeName(m.typ))
+		return
+	}
+	return
+}
+
+func (m *WsMessage) Binary() (msg *WsBinaryMessage) {
+	msg = &WsBinaryMessage{msg: m}
+	switch {
+	case m.chain.failed():
+		return
+	case m.typ != websocket.BinaryMessage:
+		m.chain.fail(
+			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
+			wsMessageTypeName(websocket.BinaryMessage),
+			wsMessageTypeName(m.typ))
+		return
+	}
+	return
+}
+
+func (m *WsMessage) Closed() (msg *WsCloseMessage) {
+	msg = &WsCloseMessage{msg: m}
+	switch {
+	case m.chain.failed():
+		return
+	case m.typ != websocket.CloseMessage:
+		m.chain.fail(
+			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
+			wsMessageTypeName(websocket.CloseMessage),
+			wsMessageTypeName(m.typ))
+		return
+	}
+	return
+}
+
+func (m *WsMessage) Ping() (msg *WsPingMessage) {
+	msg = &WsPingMessage{msg: m}
+	switch {
+	case m.chain.failed():
+		return
+	case m.typ != websocket.PingMessage:
+		m.chain.fail(
+			"\nexpected WebSocket message type:\n %s\n\nbut got:\n %s",
+			wsMessageTypeName(websocket.PingMessage),
+			wsMessageTypeName(m.typ))
+		return
+	}
+	return
+}
+
+func (m *WsMessage) Body() *String {
+	return &String{m.chain, string(m.body)}
+}
+
+func (m *WsMessage) JSON() *Value {
+	return &Value{m.chain, m.getJSON()}
+}
+
+func (m *WsMessage) NoContent() *WsMessage {
+	switch {
+	case m.chain.failed():
+		return m
+	case len(m.body) == 0:
+		return m
+	}
+	switch m.typ {
+	case websocket.BinaryMessage:
+		m.chain.fail(
+			"\nexpected message body being empty, but got:\n%d bytes",
+			len(m.body))
+	default:
+		m.chain.fail(
+			"\nexpected message body being empty, but got:\n%s",
+			string(m.body))
+	}
+	return m
+}
+
+func (m *WsMessage) Raw() (typ int, body []byte, closeCode int) {
+	return m.typ, m.body, m.closeCode
+}
+
+func (m *WsTextMessage) Body() *String {
+	return m.msg.Body()
+}
+
+func (m *WsTextMessage) JSON() *Value {
+	return m.msg.JSON()
+}
+
+func (m *WsTextMessage) NoContent() *WsTextMessage {
+	m.msg.NoContent()
+	return m
+}
+
+func (m *WsTextMessage) Raw() string {
+	return string(m.msg.body)
+}
+
+func (m *WsBinaryMessage) Body() *Value {
+	return &Value{m.msg.chain, m.msg.body}
+}
+
+func (m *WsBinaryMessage) NoContent() *WsBinaryMessage {
+	m.msg.NoContent()
+	return m
+}
+
+func (m *WsBinaryMessage) Raw() []byte {
+	return m.msg.body
+}
+
+func (m *WsCloseMessage) Body() *String {
+	return m.msg.Body()
+}
+
+func (m *WsCloseMessage) JSON() *Value {
+	return m.msg.JSON()
+}
+
+func (m *WsCloseMessage) NoContent() *WsCloseMessage {
+	m.msg.NoContent()
+	return m
+}
+
+func (m *WsCloseMessage) Raw() *websocket.CloseError {
+	return &websocket.CloseError{
+		Code: m.msg.closeCode,
+		Text: string(m.msg.body),
+	}
+}
+
+func wsMessageTypeName(typ int) string {
+	switch typ {
+	case websocket.TextMessage:
+		return "text"
+	case websocket.BinaryMessage:
+		return "binary"
+	case websocket.CloseMessage:
+		return "close"
+	case websocket.PingMessage:
+		return "ping"
+	case websocket.PongMessage:
+		return "pong"
+	}
+	return "unknown"
+}
+
+func (m *WsMessage) getJSON() interface{} {
+	if m.chain.failed() {
+		return nil
+	}
+
+	var value interface{}
+	if err := json.Unmarshal(m.body, &value); err != nil {
+		m.chain.fail(err.Error())
+		return nil
+	}
+
+	return value
+}


### PR DESCRIPTION
Resolves #50

### Why this PR is here?

I haven't found any handy solutions for E2E [WebSocket]s testing on Go. The only solution I've found is [github.com/posener/wstest](https://github.com/posener/wstest) which is for unit tests only, however.


### What does this PR do?

Adds first-class library support for [WebSocket] testing. Built on top of [github.com/gorilla/websocket](https://github.com/gorilla/websocket) library, which is de facto Go standard for [WebSocket]s at the moment.

This supports both real [WebSocket] server implemented in any language (so allows E2E tests) and `http.Handler` / `fasthttp.RequestHandler` directly without running server (so allows unit tests).

#### Features

- Send WS HTTP request: `req := e.WS("/my/path/to/ws")`
- Obtain WS connection from response: `conn := req.Expect().Connection()`
- Close WS connection normally/abnormally: `conn.Close()` / `conn.Disconnect()`
- Write to WS connection: `conn.WriteText("hi")`, `conn.WriteJSON(object)`, `conn.WriteBinary(bytes)`, and so on...
- Read from WS connection: `msg := conn.Expect()`
- `Binder` / `FastBinder` implementations for `websocket.Dialer` (to test handlers directly without running WS server)
- `WsPrinter` interface extension for `Printer` which prints sent and received [WebSocket] messages (implemented for `DebugPrinter`)

#### Example

```go
func TestEchoServer(t *testing.T) {
	e := httpexpect.New(t, "http://echo.server/")

	conn := e.WS("/endpoint/ws").
		Expect().
		Status(http.StatusSwitchingProtocols).
		Connection()
	defer conn.Disconnect()

	conn.WriteText("hi").
		Expect().Text().Body().Equal("hi")

	conn.WriteJSON(struct {
		Message string `json:"message"`
	}{"hi"}).
		Expect().
		Text().JSON().Object().ValueEqual("message", "hi")

	conn.CloseWithText("bye")
}
```


### If you want to try it now

Modify your `Gopkg.toml`:

```toml
[[constraint]]
  name = "github.com/gavv/httpexpect"
  branch = "ws-support"
  source = "github.com/instrumentisto/httpexpect"
```




[WebSocket]: https://en.wikipedia.org/wiki/WebSocket