### PR TITLE
WithRetry capability

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -57,6 +57,7 @@ func TestRequestFailed(t *testing.T) {
 	req.WithFile("foo", "bar", strings.NewReader("baz"))
 	req.WithFileBytes("foo", "bar", []byte("baz"))
 	req.WithMultipart()
+	req.WithRetry(3, time.Millisecond)
 
 	resp := req.Expect()
 	if resp == nil {


### PR DESCRIPTION
First of all, thanks for this cool library.

In my context, we would have been interested in a retry capability before to assert that a test is failing. We are running a test, synchronizing an internal cache and then we trigger an HTTP request. As we don't have the possibility to query the internal cache, we don't know when the HTTP query will succeed. Hence, we had to add an ugly time.Sleep() before calling httpexpect library.

Instead, it would be way cleaner to be able to retry a failing query. That would be something similar to what we have for example in Gomega with the `Eventually` assertion: https://onsi.github.io/gomega/#making-assertions

`WithRetry` would accept a max retry value and a retry delay.