### PR TITLE
Websocket unit tests

### DIFF
--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1,7 +1,6 @@
 package httpexpect
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 )
@@ -33,19 +32,5 @@ func newMockReporter(t *testing.T) *mockReporter {
 
 func (r *mockReporter) Errorf(message string, args ...interface{}) {
 	r.testing.Logf("Fail: "+message, args...)
-	r.reported = true
-}
-
-type stringReporter struct {
-	msg      string
-	reported bool
-}
-
-func newStringReporter() *stringReporter {
-	return &stringReporter{"", false}
-}
-
-func (r *stringReporter) Errorf(message string, args ...interface{}) {
-	r.msg = fmt.Sprintf(message, args...)
 	r.reported = true
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1,6 +1,7 @@
 package httpexpect
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -32,5 +33,19 @@ func newMockReporter(t *testing.T) *mockReporter {
 
 func (r *mockReporter) Errorf(message string, args ...interface{}) {
 	r.testing.Logf("Fail: "+message, args...)
+	r.reported = true
+}
+
+type stringReporter struct {
+	msg      string
+	reported bool
+}
+
+func newStringReporter() *stringReporter {
+	return &stringReporter{"", false}
+}
+
+func (r *stringReporter) Errorf(message string, args ...interface{}) {
+	r.msg = fmt.Sprintf(message, args...)
 	r.reported = true
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -3,6 +3,7 @@ package httpexpect
 import (
 	"net/http"
 	"testing"
+	"time"
 )
 
 type mockClient struct {
@@ -33,4 +34,104 @@ func newMockReporter(t *testing.T) *mockReporter {
 func (r *mockReporter) Errorf(message string, args ...interface{}) {
 	r.testing.Logf("Fail: "+message, args...)
 	r.reported = true
+}
+
+type mockWebsocketConn struct {
+	msgType      int
+	readMsgErr   error
+	writeMsgErr  error
+	closeError   error
+	readDlError  error
+	writeDlError error
+	msg          []byte
+	subprotocol  string
+}
+
+func newMockWebsocketConn() *mockWebsocketConn {
+	return &mockWebsocketConn{}
+}
+
+func (wc *mockWebsocketConn) WithWriteMsgError(retError error) *mockWebsocketConn {
+	wc.writeMsgErr = retError
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithReadMsgError(retError error) *mockWebsocketConn {
+	wc.readMsgErr = retError
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithWriteDlError(retError error) *mockWebsocketConn {
+	wc.writeDlError = retError
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithReadDlError(retError error) *mockWebsocketConn {
+	wc.readDlError = retError
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithCloseError(retError error) *mockWebsocketConn {
+	wc.closeError = retError
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithMsgType(msgType int) *mockWebsocketConn {
+	wc.msgType = msgType
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithSubprotocol(subprotocol string) *mockWebsocketConn {
+	wc.subprotocol = subprotocol
+	return wc
+}
+
+func (wc *mockWebsocketConn) WithMessage(msg []byte) *mockWebsocketConn {
+	wc.msg = msg
+	return wc
+}
+
+func (wc *mockWebsocketConn) ReadMessage() (messageType int, p []byte, err error) {
+	return wc.msgType, []byte{}, wc.readMsgErr
+}
+func (wc *mockWebsocketConn) WriteMessage(messageType int, data []byte) error {
+	return wc.writeMsgErr
+
+}
+func (wc *mockWebsocketConn) Close() error {
+	return wc.closeError
+}
+func (wc *mockWebsocketConn) SetReadDeadline(t time.Time) error {
+	return wc.readDlError
+}
+func (wc *mockWebsocketConn) SetWriteDeadline(t time.Time) error {
+	return wc.writeDlError
+}
+func (wc *mockWebsocketConn) Subprotocol() string {
+	return wc.subprotocol
+}
+
+type MockWsPrinter struct {
+	isWrittenTo bool
+	isReadFrom  bool
+}
+
+func newMockWsPrinter() *MockWsPrinter {
+	return &MockWsPrinter{
+		isWrittenTo: false,
+		isReadFrom:  false,
+	}
+}
+
+func (pr *MockWsPrinter) Request(*http.Request) {}
+
+// Response is called after response is received.
+func (pr *MockWsPrinter) Response(*http.Response, time.Duration) {}
+
+func (pr *MockWsPrinter) WebsocketWrite(typ int, content []byte, closeCode int) {
+	pr.isWrittenTo = true
+}
+
+func (pr *MockWsPrinter) WebsocketRead(typ int, content []byte, closeCode int) {
+	pr.isReadFrom = true
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,10 +1,14 @@
 package httpexpect
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
+
+func noWsPreSteps(ws *Websocket) {}
 
 func TestWebsocketFailed(t *testing.T) {
 	chain := makeChain(newMockReporter(t))
@@ -38,224 +42,946 @@ func TestWebsocketFailed(t *testing.T) {
 	ws.Disconnect()
 }
 
-func TestWebsocketNil(t *testing.T) {
-	config := Config{
-		Reporter: newMockReporter(t),
-	}
-
-	ws := NewWebsocket(config, nil)
-
-	msg := ws.Expect()
-	msg.chain.assertFailed(t)
-
-	ws.chain.assertFailed(t)
-}
-
 func TestWebsocketExpect(t *testing.T) {
-	t.Run("websocket is closed", func(t *testing.T) {
-		r := newMockReporter(t)
-		c := &Websocket{
-			chain:    makeChain(r),
-			conn:     &websocket.Conn{},
-			isClosed: true,
-		}
 
-		c.Expect()
+	failedChain := makeChain(newMockReporter(t))
+	failedChain.fail("some previous fail...")
 
-		if !r.reported {
-			t.Errorf("Websocket.Expect() error message not reported")
-		}
-	})
-}
-
-func TestWebsocketCheckUnusable(t *testing.T) {
-	type fields struct {
-		conn     *websocket.Conn
-		isClosed bool
-	}
 	type args struct {
-		reporter *mockReporter
-		where    string
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
 	}
 	tests := []struct {
 		name     string
-		fields   fields
 		args     args
-		want     bool
-		reported bool
+		assertOk bool
 	}{
 		{
-			name: "conn is nil",
-			fields: fields{
-				conn:     nil,
-				isClosed: false,
-			},
+			name: "Expect success",
 			args: args{
-				reporter: newMockReporter(t),
-				where:    "Close",
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
 			},
-			want:     true,
-			reported: true,
+			assertOk: true,
 		},
 		{
-			name: "websocket is closed",
-			fields: fields{
-				conn:     &websocket.Conn{},
-				isClosed: true,
-			},
+			name: "Expect failed to read message from conn",
 			args: args{
-				reporter: newMockReporter(t),
-				where:    "Close",
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn().WithReadMsgError(fmt.Errorf("failed to read message")),
 			},
-			want:     true,
-			reported: true,
+			assertOk: false,
+		},
+		{
+			name: "Expect chain already failed",
+			args: args{
+				config:     Config{},
+				chain:      failedChain,
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+			},
+			assertOk: false,
+		},
+		{
+			name: "Expect connection closed",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				wsConn: newMockWebsocketConn(),
+			},
+			assertOk: false,
+		},
+		{
+			name: "Expect failed to set read deadline",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn().WithReadDlError(fmt.Errorf("failed to set read deadline")),
+			},
+			assertOk: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Websocket{
-				chain:    makeChain(tt.args.reporter),
-				conn:     tt.fields.conn,
-				isClosed: tt.fields.isClosed,
-			}
-			if got := c.checkUnusable(tt.args.where); got != tt.want {
-				t.Errorf("Websocket.checkUnusable() = %v, want %v", got, tt.want)
-				return
-			}
-			if got := tt.args.reporter.reported; got != tt.reported {
-				t.Errorf("Websocket.checkUnusable() error message reported = %v, want %v",
-					got, tt.want)
-				return
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			tt.args.wsPreSteps(ws)
+
+			ws.Expect()
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
 			}
 		})
 	}
 }
 
-func TestWebsocketWriteJSONMarshalFail(t *testing.T) {
-	r := newMockReporter(t)
+func TestWebsocketClose(t *testing.T) {
 
-	ws := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
+	failedChain := makeChain(newMockReporter(t))
+	failedChain.fail("some previous fail...")
 
-	channel := make(chan int)
-
-	ws.WriteJSON(channel)
-
-	ws.chain.assertFailed(t)
-
-	if !r.reported {
-		t.Errorf("Websocket.WriteJSON() Error message not reported")
-		return
-	}
-}
-
-func TestWebsocketWriteMessage(t *testing.T) {
 	type args struct {
-		reporter  *mockReporter
-		typ       int
-		content   []byte
-		closeCode []int
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		closeCode  []int
 	}
 	tests := []struct {
 		name     string
 		args     args
-		reported bool
+		assertOk bool
 	}{
 		{
-			name: "Close message, multiple close code",
+			name: "Close success",
 			args: args{
-				reporter:  newMockReporter(t),
-				typ:       websocket.CloseMessage,
-				content:   []byte("closing message..."),
-				closeCode: []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				closeCode:  []int{websocket.CloseNormalClosure},
 			},
-			reported: true,
+			assertOk: true,
 		},
 		{
-			name: "Close message, multiple close code",
+			name: "Close websocket unusable",
 			args: args{
-				reporter:  newMockReporter(t),
-				typ:       websocket.PingMessage,
-				content:   []byte("closing message..."),
-				closeCode: []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				wsConn:    newMockWebsocketConn(),
+				closeCode: []int{websocket.CloseNormalClosure},
 			},
-			reported: true,
+			assertOk: false,
+		},
+		{
+			name: "Close too many close codes",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				closeCode:  []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			assertOk: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewWebsocket(Config{Reporter: tt.args.reporter}, &websocket.Conn{})
-			c.WriteMessage(tt.args.typ, tt.args.content, tt.args.closeCode...)
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
 
-			if got := tt.args.reporter.reported; got != tt.reported {
-				t.Errorf("Websocket.WriteMessage() is error message reported = %v, want %v",
-					got, tt.reported)
+			tt.args.wsPreSteps(ws)
+
+			ws.Close(tt.args.closeCode...)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocketCloseWithBytes(t *testing.T) {
+
+	failedChain := makeChain(newMockReporter(t))
+	failedChain.fail("some previous fail...")
+
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    []byte
+		closeCode  []int
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    []byte("connection closed..."),
+				closeCode:  []int{websocket.CloseNormalClosure},
+			},
+			assertOk: true,
+		},
+		{
+			name: "websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				wsConn:    newMockWebsocketConn(),
+				content:   []byte("connection closed..."),
+				closeCode: []int{websocket.CloseNormalClosure},
+			},
+			assertOk: false,
+		},
+		{
+			name: "too many close codes",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    []byte("connection closed..."),
+				closeCode:  []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			tt.args.wsPreSteps(ws)
+
+			ws.CloseWithBytes(tt.args.content, tt.args.closeCode...)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
 			}
 		})
 	}
 }
 
 func TestWebsocketCloseWithText(t *testing.T) {
-	t.Run("multiple code args", func(t *testing.T) {
-		r := newMockReporter(t)
-		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
-		c.CloseWithText("Closing...", websocket.CloseNormalClosure,
-			websocket.CloseAbnormalClosure)
+	failedChain := makeChain(newMockReporter(t))
+	failedChain.fail("some previous fail...")
 
-		if !r.reported {
-			t.Errorf("Websocket.CloseWithText() error message not reported")
-		}
-	})
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    string
+		closeCode  []int
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    "connection closed...",
+				closeCode:  []int{websocket.CloseNormalClosure},
+			},
+			assertOk: true,
+		},
+		{
+			name: "websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				wsConn:    newMockWebsocketConn(),
+				content:   "connection closed...",
+				closeCode: []int{websocket.CloseNormalClosure},
+			},
+			assertOk: false,
+		},
+		{
+			name: "too many close codes",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    "connection closed...",
+				closeCode:  []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			tt.args.wsPreSteps(ws)
+
+			ws.CloseWithText(tt.args.content, tt.args.closeCode...)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
 }
 
 func TestWebsocketCloseWithJSON(t *testing.T) {
-	t.Run("multiple code args", func(t *testing.T) {
-		r := newMockReporter(t)
-		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
-		c.CloseWithJSON("Closing...", websocket.CloseNormalClosure,
-			websocket.CloseAbnormalClosure)
+	failedChain := makeChain(newMockReporter(t))
+	failedChain.fail("some previous fail...")
 
-		if !r.reported {
-			t.Errorf("Websocket.CloseWithJSON() error message not reported")
-		}
-	})
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    interface{}
+		closeCode  []int
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content: map[string]string{
+					"msg": "connection closing...",
+				},
+				closeCode: []int{websocket.CloseNormalClosure},
+			},
+			assertOk: true,
+		},
+		{
+			name: "websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				wsConn: newMockWebsocketConn(),
+				content: map[string]string{
+					"msg": "connection closing...",
+				},
+				closeCode: []int{websocket.CloseNormalClosure},
+			},
+			assertOk: false,
+		},
+		{
+			name: "too many close codes",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content: map[string]string{
+					"msg": "connection closing...",
+				},
+				closeCode: []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			assertOk: false,
+		},
+		{
+			name: "marshall failed",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    make(chan int),
+				closeCode:  []int{websocket.CloseNormalClosure},
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
 
-	t.Run("json marshall error", func(t *testing.T) {
-		r := newMockReporter(t)
-		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
+			tt.args.wsPreSteps(ws)
 
-		c.CloseWithJSON(make(chan int), websocket.CloseAbnormalClosure)
+			ws.CloseWithJSON(tt.args.content, tt.args.closeCode...)
 
-		if !r.reported {
-			t.Errorf("Websocket.CloseWithJSON() error message not reported")
-		}
-	})
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
 }
 
-func TestWebsocketCloseWithBytes(t *testing.T) {
-	t.Run("multiple code args", func(t *testing.T) {
-		r := newMockReporter(t)
-		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
+func TestWebsocketWriteMessage(t *testing.T) {
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		typ        int
+		content    []byte
+		closeCode  []int
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "Text message success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				typ:        websocket.TextMessage,
+				content:    []byte("random message..."),
+				closeCode:  []int{},
+			},
+			assertOk: true,
+		},
+		{
+			name: "Text message fail unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				typ:       websocket.TextMessage,
+				content:   []byte("random message..."),
+				closeCode: []int{},
+			},
+			assertOk: false,
+		},
+		{
+			name: "Text message failed to set write deadline",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsConn:     newMockWebsocketConn().WithWriteDlError(fmt.Errorf("failed to set write deadline")),
+				wsPreSteps: noWsPreSteps,
+				typ:        websocket.TextMessage,
+				content:    []byte("random message..."),
+				closeCode:  []int{},
+			},
+			assertOk: false,
+		},
+		{
+			name: "Text message failed to write to conn",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsConn:     newMockWebsocketConn().WithWriteMsgError(fmt.Errorf("failed to write message to conn")),
+				wsPreSteps: noWsPreSteps,
+				typ:        websocket.TextMessage,
+				content:    []byte("random message..."),
+				closeCode:  []int{},
+			},
+			assertOk: false,
+		},
+		{
+			name: "Text binary message success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				typ:        websocket.BinaryMessage,
+				content:    []byte("random message..."),
+				closeCode:  []int{},
+			},
+			assertOk: true,
+		},
+		{
+			name: "Close message success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsConn:     newMockWebsocketConn(),
+				wsPreSteps: noWsPreSteps,
+				typ:        websocket.CloseMessage,
+				content:    []byte("closing message..."),
+				closeCode:  []int{websocket.CloseNormalClosure},
+			},
+			assertOk: true,
+		},
+		{
+			name: "Close message too many close codes",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsConn:     newMockWebsocketConn(),
+				wsPreSteps: noWsPreSteps,
+				typ:        websocket.CloseMessage,
+				content:    []byte("closing message..."),
+				closeCode:  []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			assertOk: false,
+		},
+		{
+			name: "Unsupported message type",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsConn:     newMockWebsocketConn(),
+				wsPreSteps: noWsPreSteps,
+				typ:        websocket.CloseMandatoryExtension,
+				content:    []byte("unsupported message..."),
+				closeCode:  []int{},
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
 
-		c.CloseWithBytes([]byte("Closing..."), websocket.CloseNormalClosure,
-			websocket.CloseAbnormalClosure)
+			tt.args.wsPreSteps(ws)
 
-		if !r.reported {
-			t.Errorf("Websocket.CloseWithBytes() error message not reported")
-		}
-	})
+			ws.WriteMessage(tt.args.typ, tt.args.content, tt.args.closeCode...)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
 }
 
-func TestWebsocketClose(t *testing.T) {
-	t.Run("multiple code args", func(t *testing.T) {
-		r := newMockReporter(t)
-		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
+func TestWebsocketWriteBytesBinary(t *testing.T) {
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    []byte
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "Write binary success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    []byte("random message..."),
+			},
+			assertOk: true,
+		},
+		{
+			name: "Write binary websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				content: []byte("random message..."),
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
 
-		c.Close(websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+			tt.args.wsPreSteps(ws)
 
-		if !r.reported {
-			t.Errorf("Websocket.Close() error message not reported")
-		}
-	})
+			ws.WriteBytesBinary(tt.args.content)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocketWriteBytesText(t *testing.T) {
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    []byte
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "Write bytes text success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    []byte("random message..."),
+			},
+			assertOk: true,
+		},
+		{
+			name: "Write bytes text websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				content: []byte("random message..."),
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			tt.args.wsPreSteps(ws)
+
+			ws.WriteBytesText(tt.args.content)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocketWriteText(t *testing.T) {
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "Write text success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content:    "random message...",
+			},
+			assertOk: true,
+		},
+		{
+			name: "Write text websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				content: "random message...",
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			tt.args.wsPreSteps(ws)
+
+			ws.WriteText(tt.args.content)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocketWriteJSON(t *testing.T) {
+	type args struct {
+		config     Config
+		chain      chain
+		wsConn     WebsocketConn
+		wsPreSteps func(*Websocket)
+		content    interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "Write JSON success",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsPreSteps: noWsPreSteps,
+				wsConn:     newMockWebsocketConn(),
+				content: map[string]string{
+					"msg": "random message",
+				},
+			},
+			assertOk: true,
+		},
+		{
+			name: "Write JSON websocket unusable",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+				wsPreSteps: func(ws *Websocket) {
+					ws.Disconnect()
+				},
+				content: map[string]string{
+					"msg": "random message",
+				},
+			},
+			assertOk: false,
+		},
+		{
+			name: "Write JSON marshal failed",
+			args: args{
+				config:     Config{},
+				chain:      makeChain(newMockReporter(t)),
+				wsConn:     newMockWebsocketConn(),
+				wsPreSteps: noWsPreSteps,
+				content:    make(chan int),
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			tt.args.wsPreSteps(ws)
+
+			ws.WriteJSON(tt.args.content)
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocket_Subprotocol(t *testing.T) {
+	subproto := "soap"
+	ws := NewWebsocket(Config{}, newMockWebsocketConn().WithSubprotocol(subproto))
+
+	ws.Subprotocol()
+
+	if got := ws.Subprotocol().value; got != subproto {
+		t.Errorf("Websocket.Subprotocol() = %v, want %v", got, subproto)
+	}
+}
+
+func TestWebsocket_setReadDeadline(t *testing.T) {
+	type args struct {
+		config Config
+		chain  chain
+		wsConn WebsocketConn
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "success",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+			},
+			assertOk: true,
+		},
+		{
+			name: "conn.SetReadDeadline error",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn().WithReadDlError(fmt.Errorf("Failed to set read deadline")),
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn).WithReadTimeout(time.Second)
+
+			ws.setReadDeadline()
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocket_setWriteDeadline(t *testing.T) {
+	type args struct {
+		config Config
+		chain  chain
+		wsConn WebsocketConn
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "success",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+			},
+			assertOk: true,
+		},
+		{
+			name: "conn.SetReadDeadline error",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn().WithWriteDlError(fmt.Errorf("Failed to set read deadline")),
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn).WithWriteTimeout(time.Second)
+
+			ws.setWriteDeadline()
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestWebsocket_Disconnect(t *testing.T) {
+	type args struct {
+		config Config
+		chain  chain
+		wsConn WebsocketConn
+	}
+	tests := []struct {
+		name     string
+		args     args
+		assertOk bool
+	}{
+		{
+			name: "success",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn(),
+			},
+			assertOk: true,
+		},
+		{
+			name: "conn close failed",
+			args: args{
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn().WithCloseError(fmt.Errorf("failed to close ws conn")),
+			},
+			assertOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
+
+			ws.Disconnect()
+
+			if tt.assertOk {
+				ws.chain.assertOK(t)
+			} else {
+				ws.chain.assertFailed(t)
+			}
+		})
+	}
+}
+
+func TestPrintRead(t *testing.T) {
+	printer := newMockWsPrinter()
+	config := Config{
+		Printers: []Printer{printer},
+	}
+	ws := makeWebsocket(config, makeChain(newMockReporter(t)), newMockWebsocketConn())
+
+	ws.printRead(websocket.CloseMessage, []byte("random message"), websocket.CloseNormalClosure)
+
+	if !printer.isReadFrom {
+		t.Errorf("Websocket.printRead() failed to read from printer")
+	}
+}
+
+func TestPrintWrite(t *testing.T) {
+	printer := newMockWsPrinter()
+	config := Config{
+		Printers: []Printer{printer},
+	}
+	ws := makeWebsocket(config, makeChain(newMockReporter(t)), newMockWebsocketConn())
+
+	ws.printWrite(websocket.CloseMessage, []byte("random message"), websocket.CloseNormalClosure)
+
+	if !printer.isWrittenTo {
+		t.Errorf("Websocket.printWrite() failed to write to printer")
+	}
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -11,9 +11,7 @@ func TestWebsocketFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	ws := &Websocket{
-		chain: chain,
-	}
+	ws := makeWebsocket(Config{}, chain, nil)
 
 	ws.chain.assertFailed(t)
 
@@ -65,7 +63,7 @@ func TestWebsocketExpect(t *testing.T) {
 		c.Expect()
 
 		if !r.reported {
-			t.Errorf("Websocket.CloseWithText() error message not reported")
+			t.Errorf("Websocket.Expect() error message not reported")
 		}
 	})
 }
@@ -125,7 +123,7 @@ func TestWebsocketCheckUnusable(t *testing.T) {
 				return
 			}
 			if got := tt.args.reporter.reported; got != tt.reported {
-				t.Errorf("Websocket.checkUnusable() is error message reported = %v, want %v",
+				t.Errorf("Websocket.checkUnusable() error message reported = %v, want %v",
 					got, tt.want)
 				return
 			}
@@ -136,11 +134,7 @@ func TestWebsocketCheckUnusable(t *testing.T) {
 func TestWebsocketWriteJSONMarshalFail(t *testing.T) {
 	r := newMockReporter(t)
 
-	ws := &Websocket{
-		chain:    makeChain(r),
-		conn:     &websocket.Conn{},
-		isClosed: false,
-	}
+	ws := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
 	channel := make(chan int)
 
@@ -149,7 +143,7 @@ func TestWebsocketWriteJSONMarshalFail(t *testing.T) {
 	ws.chain.assertFailed(t)
 
 	if !r.reported {
-		t.Errorf("Error message not reported")
+		t.Errorf("Websocket.WriteJSON() Error message not reported")
 		return
 	}
 }
@@ -189,12 +183,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Websocket{
-				chain:    makeChain(tt.args.reporter),
-				conn:     &websocket.Conn{},
-				isClosed: false,
-			}
-
+			c := NewWebsocket(Config{Reporter: tt.args.reporter}, &websocket.Conn{})
 			c.WriteMessage(tt.args.typ, tt.args.content, tt.args.closeCode...)
 
 			if got := tt.args.reporter.reported; got != tt.reported {
@@ -208,11 +197,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 func TestWebsocketCloseWithText(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newMockReporter(t)
-		c := &Websocket{
-			chain:    makeChain(r),
-			conn:     &websocket.Conn{},
-			isClosed: false,
-		}
+		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
 		c.CloseWithText("Closing...", websocket.CloseNormalClosure,
 			websocket.CloseAbnormalClosure)
@@ -226,32 +211,24 @@ func TestWebsocketCloseWithText(t *testing.T) {
 func TestWebsocketCloseWithJSON(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newMockReporter(t)
-		c := &Websocket{
-			chain:    makeChain(r),
-			conn:     &websocket.Conn{},
-			isClosed: false,
-		}
+		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
 		c.CloseWithJSON("Closing...", websocket.CloseNormalClosure,
 			websocket.CloseAbnormalClosure)
 
 		if !r.reported {
-			t.Errorf("Websocket.CloseWithText() error message not reported")
+			t.Errorf("Websocket.CloseWithJSON() error message not reported")
 		}
 	})
 
 	t.Run("json marshall error", func(t *testing.T) {
 		r := newMockReporter(t)
-		c := &Websocket{
-			chain:    makeChain(r),
-			conn:     &websocket.Conn{},
-			isClosed: false,
-		}
+		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
 		c.CloseWithJSON(make(chan int), websocket.CloseAbnormalClosure)
 
 		if !r.reported {
-			t.Errorf("Websocket.CloseWithText() error message not reported")
+			t.Errorf("Websocket.CloseWithJSON() error message not reported")
 		}
 	})
 }
@@ -259,17 +236,13 @@ func TestWebsocketCloseWithJSON(t *testing.T) {
 func TestWebsocketCloseWithBytes(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newMockReporter(t)
-		c := &Websocket{
-			chain:    makeChain(r),
-			conn:     &websocket.Conn{},
-			isClosed: false,
-		}
+		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
 		c.CloseWithBytes([]byte("Closing..."), websocket.CloseNormalClosure,
 			websocket.CloseAbnormalClosure)
 
 		if !r.reported {
-			t.Errorf("Websocket.CloseWithText() error message not reported")
+			t.Errorf("Websocket.CloseWithBytes() error message not reported")
 		}
 	})
 }
@@ -277,16 +250,12 @@ func TestWebsocketCloseWithBytes(t *testing.T) {
 func TestWebsocketClose(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newMockReporter(t)
-		c := &Websocket{
-			chain:    makeChain(r),
-			conn:     &websocket.Conn{},
-			isClosed: false,
-		}
+		c := NewWebsocket(Config{Reporter: r}, &websocket.Conn{})
 
 		c.Close(websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
 
 		if !r.reported {
-			t.Errorf("Websocket.CloseWithText() error message not reported")
+			t.Errorf("Websocket.Close() error message not reported")
 		}
 	})
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -43,7 +43,6 @@ func TestWebsocketFailed(t *testing.T) {
 }
 
 func TestWebsocketExpect(t *testing.T) {
-
 	failedChain := makeChain(newMockReporter(t))
 	failedChain.fail("some previous fail...")
 
@@ -59,7 +58,7 @@ func TestWebsocketExpect(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Expect success",
+			name: "success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -69,17 +68,18 @@ func TestWebsocketExpect(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Expect failed to read message from conn",
+			name: "fail to read message from conn",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
 				wsPreSteps: noWsPreSteps,
-				wsConn:     newMockWebsocketConn().WithReadMsgError(fmt.Errorf("failed to read message")),
+				wsConn: newMockWebsocketConn().WithReadMsgError(
+					fmt.Errorf("failed to read message")),
 			},
 			assertOk: false,
 		},
 		{
-			name: "Expect chain already failed",
+			name: "chain already failed",
 			args: args{
 				config:     Config{},
 				chain:      failedChain,
@@ -89,7 +89,7 @@ func TestWebsocketExpect(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Expect connection closed",
+			name: "connection closed",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -101,12 +101,13 @@ func TestWebsocketExpect(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Expect failed to set read deadline",
+			name: "failed to set read deadline",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
 				wsPreSteps: noWsPreSteps,
-				wsConn:     newMockWebsocketConn().WithReadDlError(fmt.Errorf("failed to set read deadline")),
+				wsConn: newMockWebsocketConn().WithReadDlError(
+					fmt.Errorf("failed to set read deadline")),
 			},
 			assertOk: false,
 		},
@@ -114,7 +115,6 @@ func TestWebsocketExpect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn)
-
 			tt.args.wsPreSteps(ws)
 
 			ws.Expect()
@@ -146,7 +146,7 @@ func TestWebsocketClose(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Close success",
+			name: "success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -157,7 +157,7 @@ func TestWebsocketClose(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Close websocket unusable",
+			name: "websocket unusable",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -170,7 +170,7 @@ func TestWebsocketClose(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Close too many close codes",
+			name: "too many close codes",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -454,7 +454,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Text message success",
+			name: "text message success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -467,7 +467,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Text message fail unusable",
+			name: "text message fail unusable",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -482,11 +482,12 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Text message failed to set write deadline",
+			name: "text message failed to set write deadline",
 			args: args{
-				config:     Config{},
-				chain:      makeChain(newMockReporter(t)),
-				wsConn:     newMockWebsocketConn().WithWriteDlError(fmt.Errorf("failed to set write deadline")),
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn().WithWriteDlError(
+					fmt.Errorf("failed to set write deadline")),
 				wsPreSteps: noWsPreSteps,
 				typ:        websocket.TextMessage,
 				content:    []byte("random message..."),
@@ -495,11 +496,12 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Text message failed to write to conn",
+			name: "text message failed to write to conn",
 			args: args{
-				config:     Config{},
-				chain:      makeChain(newMockReporter(t)),
-				wsConn:     newMockWebsocketConn().WithWriteMsgError(fmt.Errorf("failed to write message to conn")),
+				config: Config{},
+				chain:  makeChain(newMockReporter(t)),
+				wsConn: newMockWebsocketConn().WithWriteMsgError(
+					fmt.Errorf("failed to write message to conn")),
 				wsPreSteps: noWsPreSteps,
 				typ:        websocket.TextMessage,
 				content:    []byte("random message..."),
@@ -508,7 +510,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Text binary message success",
+			name: "text binary message success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -521,7 +523,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Close message success",
+			name: "close message success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -534,7 +536,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Close message too many close codes",
+			name: "close message too many close codes",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -547,7 +549,7 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Unsupported message type",
+			name: "unsupported message type",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -591,7 +593,7 @@ func TestWebsocketWriteBytesBinary(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Write binary success",
+			name: "success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -602,7 +604,7 @@ func TestWebsocketWriteBytesBinary(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Write binary websocket unusable",
+			name: "websocket unusable",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -646,7 +648,7 @@ func TestWebsocketWriteBytesText(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Write bytes text success",
+			name: "success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -657,7 +659,7 @@ func TestWebsocketWriteBytesText(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Write bytes text websocket unusable",
+			name: "websocket unusable",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -701,7 +703,7 @@ func TestWebsocketWriteText(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Write text success",
+			name: "success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -712,7 +714,7 @@ func TestWebsocketWriteText(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Write text websocket unusable",
+			name: "websocket unusable",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -756,7 +758,7 @@ func TestWebsocketWriteJSON(t *testing.T) {
 		assertOk bool
 	}{
 		{
-			name: "Write JSON success",
+			name: "success",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -769,7 +771,7 @@ func TestWebsocketWriteJSON(t *testing.T) {
 			assertOk: true,
 		},
 		{
-			name: "Write JSON websocket unusable",
+			name: "websocket unusable",
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
@@ -784,7 +786,7 @@ func TestWebsocketWriteJSON(t *testing.T) {
 			assertOk: false,
 		},
 		{
-			name: "Write JSON marshal failed",
+			name: "JSON marshal failed",
 			args: args{
 				config:     Config{},
 				chain:      makeChain(newMockReporter(t)),
@@ -848,14 +850,16 @@ func TestWebsocket_setReadDeadline(t *testing.T) {
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
-				wsConn: newMockWebsocketConn().WithReadDlError(fmt.Errorf("Failed to set read deadline")),
+				wsConn: newMockWebsocketConn().WithReadDlError(
+					fmt.Errorf("Failed to set read deadline")),
 			},
 			assertOk: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn).WithReadTimeout(time.Second)
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn).
+				WithReadTimeout(time.Second)
 
 			ws.setReadDeadline()
 
@@ -893,14 +897,16 @@ func TestWebsocket_setWriteDeadline(t *testing.T) {
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
-				wsConn: newMockWebsocketConn().WithWriteDlError(fmt.Errorf("Failed to set read deadline")),
+				wsConn: newMockWebsocketConn().WithWriteDlError(
+					fmt.Errorf("Failed to set read deadline")),
 			},
 			assertOk: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn).WithWriteTimeout(time.Second)
+			ws := makeWebsocket(tt.args.config, tt.args.chain, tt.args.wsConn).
+				WithWriteTimeout(time.Second)
 
 			ws.setWriteDeadline()
 
@@ -938,7 +944,8 @@ func TestWebsocket_Disconnect(t *testing.T) {
 			args: args{
 				config: Config{},
 				chain:  makeChain(newMockReporter(t)),
-				wsConn: newMockWebsocketConn().WithCloseError(fmt.Errorf("failed to close ws conn")),
+				wsConn: newMockWebsocketConn().WithCloseError(
+					fmt.Errorf("failed to close ws conn")),
 			},
 			assertOk: false,
 		},
@@ -965,7 +972,9 @@ func TestPrintRead(t *testing.T) {
 	}
 	ws := makeWebsocket(config, makeChain(newMockReporter(t)), newMockWebsocketConn())
 
-	ws.printRead(websocket.CloseMessage, []byte("random message"), websocket.CloseNormalClosure)
+	ws.printRead(websocket.CloseMessage,
+		[]byte("random message"),
+		websocket.CloseNormalClosure)
 
 	if !printer.isReadFrom {
 		t.Errorf("Websocket.printRead() failed to read from printer")
@@ -979,7 +988,9 @@ func TestPrintWrite(t *testing.T) {
 	}
 	ws := makeWebsocket(config, makeChain(newMockReporter(t)), newMockWebsocketConn())
 
-	ws.printWrite(websocket.CloseMessage, []byte("random message"), websocket.CloseNormalClosure)
+	ws.printWrite(websocket.CloseMessage,
+		[]byte("random message"),
+		websocket.CloseNormalClosure)
 
 	if !printer.isWrittenTo {
 		t.Errorf("Websocket.printWrite() failed to write to printer")

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -52,3 +52,281 @@ func TestWebsocketNil(t *testing.T) {
 
 	ws.chain.assertFailed(t)
 }
+
+func TestWebsocket_Expect(t *testing.T) {
+
+	t.Run("websocket is closed", func(t *testing.T) {
+		r := newStringReporter()
+		c := &Websocket{
+			chain:    makeChain(r),
+			conn:     &websocket.Conn{},
+			isClosed: true,
+		}
+
+		c.Expect()
+
+		if !r.reported {
+			t.Errorf("Websocket.CloseWithText() error message not reported")
+		}
+
+		want := "\nunexpected read from closed WebSocket connection"
+
+		if got := r.msg; got != want {
+			t.Errorf("Websocket.CloseWithText() = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestWebsocket_checkUnusable(t *testing.T) {
+	type fields struct {
+		conn     *websocket.Conn
+		isClosed bool
+	}
+	type args struct {
+		reporter *stringReporter
+		where    string
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     bool
+		reported bool
+		wantMsg  string
+	}{
+		{
+			name: "conn is nil",
+			fields: fields{
+				conn:     nil,
+				isClosed: false,
+			},
+			args: args{
+				reporter: newStringReporter(),
+				where:    "Close",
+			},
+			want:     true,
+			reported: true,
+			wantMsg:  "\nunexpected Close call for failed WebSocket connection",
+		},
+		{
+			name: "websocket is closed",
+			fields: fields{
+				conn:     &websocket.Conn{},
+				isClosed: true,
+			},
+			args: args{
+				reporter: newStringReporter(),
+				where:    "Close",
+			},
+			want:     true,
+			reported: true,
+			wantMsg:  "\nunexpected Close call for closed WebSocket connection",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Websocket{
+				chain:    makeChain(tt.args.reporter),
+				conn:     tt.fields.conn,
+				isClosed: tt.fields.isClosed,
+			}
+			if got := c.checkUnusable(tt.args.where); got != tt.want {
+				t.Errorf("Websocket.checkUnusable() = %v, want %v", got, tt.want)
+				return
+			}
+			if got := tt.args.reporter.reported; got != tt.reported {
+				t.Errorf("Websocket.checkUnusable() is error message reported = %v, want %v", got, tt.want)
+				return
+			}
+			if got := tt.args.reporter.msg; got != tt.wantMsg {
+				t.Errorf("Websocket.checkUnusable() error message = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func TestWriteJSONMarshalFail(t *testing.T) {
+	r := newStringReporter()
+
+	ws := &Websocket{
+		chain:    makeChain(r),
+		conn:     &websocket.Conn{},
+		isClosed: false,
+	}
+
+	channel := make(chan int)
+
+	ws.WriteJSON(channel)
+
+	ws.chain.assertFailed(t)
+
+	if !r.reported {
+		t.Errorf("Error message not reported")
+		return
+	}
+}
+
+func TestWebsocket_WriteMessage(t *testing.T) {
+	type args struct {
+		reporter  *stringReporter
+		typ       int
+		content   []byte
+		closeCode []int
+	}
+	tests := []struct {
+		name        string
+		args        args
+		reported    bool
+		reportedMsg string
+	}{
+		{
+			name: "Close message, multiple close code",
+			args: args{
+				reporter:  newStringReporter(),
+				typ:       websocket.CloseMessage,
+				content:   []byte("closing message..."),
+				closeCode: []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			reported:    true,
+			reportedMsg: "\nunexpected multiple closeCode arguments passed to WriteMessage",
+		},
+		{
+			name: "Close message, multiple close code",
+			args: args{
+				reporter:  newStringReporter(),
+				typ:       websocket.PingMessage,
+				content:   []byte("closing message..."),
+				closeCode: []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure},
+			},
+			reported:    true,
+			reportedMsg: "\nunexpected WebSocket message type 'ping' passed to WriteMessage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Websocket{
+				chain:    makeChain(tt.args.reporter),
+				conn:     &websocket.Conn{},
+				isClosed: false,
+			}
+
+			c.WriteMessage(tt.args.typ, tt.args.content, tt.args.closeCode...)
+
+			if got := tt.args.reporter.reported; got != tt.reported {
+				t.Errorf("Websocket.WriteMessage() is error message reported = %v, want %v", got, tt.reported)
+			}
+
+			if got := tt.args.reporter.msg; got != tt.reportedMsg {
+				t.Errorf("Websocket.WriteMessage() error message = %v, want %v", got, tt.reportedMsg)
+			}
+		})
+	}
+}
+
+func TestWebsocket_CloseWithText(t *testing.T) {
+	t.Run("multiple code args", func(t *testing.T) {
+		r := newStringReporter()
+		c := &Websocket{
+			chain:    makeChain(r),
+			conn:     &websocket.Conn{},
+			isClosed: false,
+		}
+
+		c.CloseWithText("Closing...", websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+
+		if !r.reported {
+			t.Errorf("Websocket.CloseWithText() error message not reported")
+		}
+
+		want := "\nunexpected multiple code arguments passed to CloseWithText"
+
+		if got := r.msg; got != want {
+			t.Errorf("Websocket.CloseWithText() = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestWebsocket_CloseWithJSON(t *testing.T) {
+	t.Run("multiple code args", func(t *testing.T) {
+		r := newStringReporter()
+		c := &Websocket{
+			chain:    makeChain(r),
+			conn:     &websocket.Conn{},
+			isClosed: false,
+		}
+
+		c.CloseWithJSON("Closing...", websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+
+		if !r.reported {
+			t.Errorf("Websocket.CloseWithText() error message not reported")
+		}
+
+		want := "\nunexpected multiple code arguments passed to CloseWithJSON"
+
+		if got := r.msg; got != want {
+			t.Errorf("Websocket.CloseWithText() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("json marshall error", func(t *testing.T) {
+		r := newStringReporter()
+		c := &Websocket{
+			chain:    makeChain(r),
+			conn:     &websocket.Conn{},
+			isClosed: false,
+		}
+
+		c.CloseWithJSON(make(chan int), websocket.CloseAbnormalClosure)
+
+		if !r.reported {
+			t.Errorf("Websocket.CloseWithText() error message not reported")
+		}
+	})
+}
+
+func TestWebsocket_CloseWithBytes(t *testing.T) {
+	t.Run("multiple code args", func(t *testing.T) {
+		r := newStringReporter()
+		c := &Websocket{
+			chain:    makeChain(r),
+			conn:     &websocket.Conn{},
+			isClosed: false,
+		}
+
+		c.CloseWithBytes([]byte("Closing..."), websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+
+		if !r.reported {
+			t.Errorf("Websocket.CloseWithText() error message not reported")
+		}
+
+		want := "\nunexpected multiple code arguments passed to CloseWithBytes"
+
+		if got := r.msg; got != want {
+			t.Errorf("Websocket.CloseWithText() = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestWebsocket_Close(t *testing.T) {
+	t.Run("multiple code args", func(t *testing.T) {
+		r := newStringReporter()
+		c := &Websocket{
+			chain:    makeChain(r),
+			conn:     &websocket.Conn{},
+			isClosed: false,
+		}
+
+		c.Close(websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+
+		if !r.reported {
+			t.Errorf("Websocket.CloseWithText() error message not reported")
+		}
+
+		want := "\nunexpected multiple code arguments passed to Close"
+
+		if got := r.msg; got != want {
+			t.Errorf("Websocket.CloseWithText() = %v, want %v", got, want)
+		}
+	})
+}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -53,7 +53,7 @@ func TestWebsocketNil(t *testing.T) {
 	ws.chain.assertFailed(t)
 }
 
-func TestWebsocket_Expect(t *testing.T) {
+func TestWebsocketExpect(t *testing.T) {
 
 	t.Run("websocket is closed", func(t *testing.T) {
 		r := newStringReporter()
@@ -77,7 +77,7 @@ func TestWebsocket_Expect(t *testing.T) {
 	})
 }
 
-func TestWebsocket_checkUnusable(t *testing.T) {
+func TestWebsocketCheckUnusable(t *testing.T) {
 	type fields struct {
 		conn     *websocket.Conn
 		isClosed bool
@@ -146,7 +146,7 @@ func TestWebsocket_checkUnusable(t *testing.T) {
 	}
 }
 
-func TestWriteJSONMarshalFail(t *testing.T) {
+func TestWebsocketWriteJSONMarshalFail(t *testing.T) {
 	r := newStringReporter()
 
 	ws := &Websocket{
@@ -167,7 +167,7 @@ func TestWriteJSONMarshalFail(t *testing.T) {
 	}
 }
 
-func TestWebsocket_WriteMessage(t *testing.T) {
+func TestWebsocketWriteMessage(t *testing.T) {
 	type args struct {
 		reporter  *stringReporter
 		typ       int
@@ -224,7 +224,7 @@ func TestWebsocket_WriteMessage(t *testing.T) {
 	}
 }
 
-func TestWebsocket_CloseWithText(t *testing.T) {
+func TestWebsocketCloseWithText(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newStringReporter()
 		c := &Websocket{
@@ -247,7 +247,7 @@ func TestWebsocket_CloseWithText(t *testing.T) {
 	})
 }
 
-func TestWebsocket_CloseWithJSON(t *testing.T) {
+func TestWebsocketCloseWithJSON(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newStringReporter()
 		c := &Websocket{
@@ -285,7 +285,7 @@ func TestWebsocket_CloseWithJSON(t *testing.T) {
 	})
 }
 
-func TestWebsocket_CloseWithBytes(t *testing.T) {
+func TestWebsocketCloseWithBytes(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newStringReporter()
 		c := &Websocket{
@@ -308,7 +308,7 @@ func TestWebsocket_CloseWithBytes(t *testing.T) {
 	})
 }
 
-func TestWebsocket_Close(t *testing.T) {
+func TestWebsocketClose(t *testing.T) {
 	t.Run("multiple code args", func(t *testing.T) {
 		r := newStringReporter()
 		c := &Websocket{

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -135,7 +135,8 @@ func TestWebsocketCheckUnusable(t *testing.T) {
 				return
 			}
 			if got := tt.args.reporter.reported; got != tt.reported {
-				t.Errorf("Websocket.checkUnusable() is error message reported = %v, want %v", got, tt.want)
+				t.Errorf("Websocket.checkUnusable() is error message reported = %v, want %v",
+					got, tt.want)
 				return
 			}
 			if got := tt.args.reporter.msg; got != tt.wantMsg {
@@ -214,7 +215,8 @@ func TestWebsocketWriteMessage(t *testing.T) {
 			c.WriteMessage(tt.args.typ, tt.args.content, tt.args.closeCode...)
 
 			if got := tt.args.reporter.reported; got != tt.reported {
-				t.Errorf("Websocket.WriteMessage() is error message reported = %v, want %v", got, tt.reported)
+				t.Errorf("Websocket.WriteMessage() is error message reported = %v, want %v",
+					got, tt.reported)
 			}
 
 			if got := tt.args.reporter.msg; got != tt.reportedMsg {
@@ -233,7 +235,8 @@ func TestWebsocketCloseWithText(t *testing.T) {
 			isClosed: false,
 		}
 
-		c.CloseWithText("Closing...", websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+		c.CloseWithText("Closing...", websocket.CloseNormalClosure,
+			websocket.CloseAbnormalClosure)
 
 		if !r.reported {
 			t.Errorf("Websocket.CloseWithText() error message not reported")
@@ -256,7 +259,8 @@ func TestWebsocketCloseWithJSON(t *testing.T) {
 			isClosed: false,
 		}
 
-		c.CloseWithJSON("Closing...", websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+		c.CloseWithJSON("Closing...", websocket.CloseNormalClosure,
+			websocket.CloseAbnormalClosure)
 
 		if !r.reported {
 			t.Errorf("Websocket.CloseWithText() error message not reported")
@@ -294,7 +298,8 @@ func TestWebsocketCloseWithBytes(t *testing.T) {
 			isClosed: false,
 		}
 
-		c.CloseWithBytes([]byte("Closing..."), websocket.CloseNormalClosure, websocket.CloseAbnormalClosure)
+		c.CloseWithBytes([]byte("Closing..."), websocket.CloseNormalClosure,
+			websocket.CloseAbnormalClosure)
 
 		if !r.reported {
 			t.Errorf("Websocket.CloseWithText() error message not reported")


### PR DESCRIPTION
As requested in #70 more unit tests for websockets are added. New tests cover cases where gorillamux websocket Conn type is not needed or empty one is sufficient.