### PR TITLE
Docs: typo in docstring of Array.Elements

### DIFF
--- a/array.go
+++ b/array.go
@@ -211,7 +211,7 @@ func (a *Array) NotEqual(value interface{}) *Array {
 //  array.Elements("foo", 123)
 //
 // This calls are equivalent:
-//  array.Elelems("a", "b")
+//  array.Elements("a", "b")
 //  array.Equal([]interface{}{"a", "b"})
 func (a *Array) Elements(values ...interface{}) *Array {
 	return a.Equal(values)


### PR DESCRIPTION
Hey,

This PR is very **non critical**.

I encountered a typo of the method signature when reading the examples for usage of the `Array.Elements` method.