### PR TITLE
Update README, 'BaseURL' required for proper cookie handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,9 @@ e := httpexpect.WithConfig(httpexpect.Config{
 var handler http.Handler = MyHandler()
 
 e := httpexpect.WithConfig(httpexpect.Config{
+	// prepend this url to all requests, required for cookies
+	// to be handled correctly
+	BaseURL: "http://example.com",
 	Reporter: httpexpect.NewAssertReporter(t),
 	Client: &http.Client{
 		Transport: httpexpect.NewBinder(handler),
@@ -450,6 +453,9 @@ e := httpexpect.WithConfig(httpexpect.Config{
 var handler fasthttp.RequestHandler = myHandler()
 
 e := httpexpect.WithConfig(httpexpect.Config{
+	// prepend this url to all requests, required for cookies
+	// to be handled correctly
+	BaseURL: "http://example.com",
 	Reporter: httpexpect.NewAssertReporter(t),
 	Client: &http.Client{
 		Transport: httpexpect.NewFastBinder(handler),


### PR DESCRIPTION
First of all, awesome library!

I tried to go the networkless way of using ```Client``` with a custom ```Binder``` and noticed my sessions not to be handled correctly. Happened to be a problem with the cookies not being stored - caused by the fact that Golang's ```CookieJar``` implementation discards cookies given to it in case of the scheme not being HTTP or HTTPS (https://golang.org/pkg/net/http/cookiejar/#Jar.SetCookies).
Not setting a ```BaseURL``` when initiliasing httpexpect leads to this problem, setting it fixes it. Thought it therefore would be nice to have the snipped in the README fixed ;)