### PR TITLE
Add a key to the fail message report

### DIFF
--- a/array.go
+++ b/array.go
@@ -9,6 +9,7 @@ import (
 type Array struct {
 	chain chain
 	value []interface{}
+	key   string
 }
 
 // NewArray returns a new Array given a reporter used to report failures
@@ -26,7 +27,7 @@ func NewArray(reporter Reporter, value []interface{}) *Array {
 	} else {
 		value, _ = canonArray(&chain, value)
 	}
-	return &Array{chain, value}
+	return &Array{chain, value, ""}
 }
 
 // Raw returns underlying value attached to Array.
@@ -56,7 +57,7 @@ func (a *Array) Schema(schema interface{}) *Array {
 //  array := NewArray(t, []interface{}{1, 2, 3})
 //  array.Length().Equal(3)
 func (a *Array) Length() *Number {
-	return &Number{a.chain, float64(len(a.value))}
+	return &Number{a.chain, float64(len(a.value)), a.key}
 }
 
 // Element returns a new Value object that may be used to inspect array element
@@ -76,9 +77,9 @@ func (a *Array) Element(index int) *Value {
 			index,
 			0,
 			len(a.value))
-		return &Value{a.chain, nil}
+		return &Value{a.chain, nil, ""}
 	}
-	return &Value{a.chain, a.value[index]}
+	return &Value{a.chain, a.value[index], ""}
 }
 
 // First returns a new Value object that may be used to inspect first element
@@ -93,9 +94,9 @@ func (a *Array) Element(index int) *Value {
 func (a *Array) First() *Value {
 	if len(a.value) < 1 {
 		a.chain.fail("\narray is empty")
-		return &Value{a.chain, nil}
+		return &Value{a.chain, nil, ""}
 	}
-	return &Value{a.chain, a.value[0]}
+	return &Value{a.chain, a.value[0], ""}
 }
 
 // Last returns a new Value object that may be used to inspect last element
@@ -110,9 +111,9 @@ func (a *Array) First() *Value {
 func (a *Array) Last() *Value {
 	if len(a.value) < 1 {
 		a.chain.fail("\narray is empty")
-		return &Value{a.chain, nil}
+		return &Value{a.chain, nil, ""}
 	}
-	return &Value{a.chain, a.value[len(a.value)-1]}
+	return &Value{a.chain, a.value[len(a.value)-1], ""}
 }
 
 // Iter returns a new slice of Values attached to array elements.
@@ -130,7 +131,7 @@ func (a *Array) Iter() []Value {
 	}
 	ret := []Value{}
 	for n := range a.value {
-		ret = append(ret, Value{a.chain, a.value[n]})
+		ret = append(ret, Value{a.chain, a.value[n], ""})
 	}
 	return ret
 }

--- a/array_test.go
+++ b/array_test.go
@@ -11,7 +11,7 @@ func TestArrayFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	value := &Array{chain, nil}
+	value := &Array{chain, nil, ""}
 
 	value.chain.assertFailed(t)
 

--- a/boolean.go
+++ b/boolean.go
@@ -47,7 +47,7 @@ func (b *Boolean) Schema(schema interface{}) *Boolean {
 //  boolean.Equal(true)
 func (b *Boolean) Equal(value bool) *Boolean {
 	if !(b.value == value) {
-		b.chain.fail("\nkey:%s\nexpected boolean == %v, but got %v", b.key, value, b.value)
+		b.chain.fail("\nkey:%s\n\nexpected boolean == %v, but got %v", b.key, value, b.value)
 	}
 	return b
 }
@@ -59,7 +59,7 @@ func (b *Boolean) Equal(value bool) *Boolean {
 //  boolean.NotEqual(false)
 func (b *Boolean) NotEqual(value bool) *Boolean {
 	if !(b.value != value) {
-		b.chain.fail("\nkey:%s\nexpected boolean != %v, but got %v", b.key, value, b.value)
+		b.chain.fail("\nkey:%s\n\nexpected boolean != %v, but got %v", b.key, value, b.value)
 	}
 	return b
 }

--- a/boolean.go
+++ b/boolean.go
@@ -5,6 +5,7 @@ package httpexpect
 type Boolean struct {
 	chain chain
 	value bool
+	key   string
 }
 
 // NewBoolean returns a new Boolean given a reporter used to report
@@ -15,7 +16,7 @@ type Boolean struct {
 // Example:
 //  boolean := NewBoolean(t, true)
 func NewBoolean(reporter Reporter, value bool) *Boolean {
-	return &Boolean{makeChain(reporter), value}
+	return &Boolean{makeChain(reporter), value, ""}
 }
 
 // Raw returns underlying value attached to Boolean.
@@ -46,7 +47,7 @@ func (b *Boolean) Schema(schema interface{}) *Boolean {
 //  boolean.Equal(true)
 func (b *Boolean) Equal(value bool) *Boolean {
 	if !(b.value == value) {
-		b.chain.fail("expected boolean == %v, but got %v", value, b.value)
+		b.chain.fail("\nkey:%s\nexpected boolean == %v, but got %v", b.key, value, b.value)
 	}
 	return b
 }
@@ -58,7 +59,7 @@ func (b *Boolean) Equal(value bool) *Boolean {
 //  boolean.NotEqual(false)
 func (b *Boolean) NotEqual(value bool) *Boolean {
 	if !(b.value != value) {
-		b.chain.fail("expected boolean != %v, but got %v", value, b.value)
+		b.chain.fail("\nkey:%s\nexpected boolean != %v, but got %v", b.key, value, b.value)
 	}
 	return b
 }

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -11,7 +11,7 @@ func TestBooleanFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	value := &Boolean{chain, false}
+	value := &Boolean{chain, false, ""}
 
 	value.chain.assertFailed(t)
 

--- a/cookie.go
+++ b/cookie.go
@@ -47,9 +47,9 @@ func (c *Cookie) Raw() *http.Cookie {
 //  cookie.Name().Equal("session")
 func (c *Cookie) Name() *String {
 	if c.chain.failed() {
-		return &String{c.chain, ""}
+		return &String{c.chain, "", ""}
 	}
-	return &String{c.chain, c.value.Name}
+	return &String{c.chain, c.value.Name, ""}
 }
 
 // Value returns a new String object that may be used to inspect
@@ -60,9 +60,9 @@ func (c *Cookie) Name() *String {
 //  cookie.Value().Equal("gH6z7Y")
 func (c *Cookie) Value() *String {
 	if c.chain.failed() {
-		return &String{c.chain, ""}
+		return &String{c.chain, "", ""}
 	}
-	return &String{c.chain, c.value.Value}
+	return &String{c.chain, c.value.Value, ""}
 }
 
 // Domain returns a new String object that may be used to inspect
@@ -73,9 +73,9 @@ func (c *Cookie) Value() *String {
 //  cookie.Domain().Equal("example.com")
 func (c *Cookie) Domain() *String {
 	if c.chain.failed() {
-		return &String{c.chain, ""}
+		return &String{c.chain, "", ""}
 	}
-	return &String{c.chain, c.value.Domain}
+	return &String{c.chain, c.value.Domain, ""}
 }
 
 // Path returns a new String object that may be used to inspect
@@ -86,9 +86,9 @@ func (c *Cookie) Domain() *String {
 //  cookie.Path().Equal("/foo")
 func (c *Cookie) Path() *String {
 	if c.chain.failed() {
-		return &String{c.chain, ""}
+		return &String{c.chain, "", ""}
 	}
-	return &String{c.chain, c.value.Path}
+	return &String{c.chain, c.value.Path, ""}
 }
 
 // Expires returns a new DateTime object that may be used to inspect
@@ -99,9 +99,9 @@ func (c *Cookie) Path() *String {
 //  cookie.Expires().InRange(time.Now(), time.Now().Add(time.Hour * 24))
 func (c *Cookie) Expires() *DateTime {
 	if c.chain.failed() {
-		return &DateTime{c.chain, time.Unix(0, 0)}
+		return &DateTime{c.chain, time.Unix(0, 0), ""}
 	}
-	return &DateTime{c.chain, c.value.Expires}
+	return &DateTime{c.chain, c.value.Expires, ""}
 }
 
 // MaxAge returns a new Duration object that may be used to inspect

--- a/datetime.go
+++ b/datetime.go
@@ -8,6 +8,7 @@ import (
 type DateTime struct {
 	chain chain
 	value time.Time
+	key   string
 }
 
 // NewDateTime returns a new DateTime object given a reporter used to report
@@ -22,7 +23,7 @@ type DateTime struct {
 //   time.Sleep(time.Second)
 //   dt.Lt(time.Now())
 func NewDateTime(reporter Reporter, value time.Time) *DateTime {
-	return &DateTime{makeChain(reporter), value}
+	return &DateTime{makeChain(reporter), value, ""}
 }
 
 // Raw returns underlying time.Time value attached to DateTime.
@@ -42,8 +43,8 @@ func (dt *DateTime) Raw() time.Time {
 //  dt.Equal(time.Unix(0, 1))
 func (dt *DateTime) Equal(value time.Time) *DateTime {
 	if !dt.value.Equal(value) {
-		dt.chain.fail("\nexpected datetime equal to:\n %s\n\nbut got:\n %s",
-			value, dt.value)
+		dt.chain.fail("\nkey:%s\nexpected datetime equal to:\n %s\n\nbut got:\n %s",
+			dt.key, value, dt.value)
 	}
 	return dt
 }
@@ -55,7 +56,8 @@ func (dt *DateTime) Equal(value time.Time) *DateTime {
 //  dt.NotEqual(time.Unix(0, 2))
 func (dt *DateTime) NotEqual(value time.Time) *DateTime {
 	if dt.value.Equal(value) {
-		dt.chain.fail("\nexpected datetime not equal to:\n %s", value)
+		dt.chain.fail("\nkey:%s\nexpected datetime not equal to:\n %s",
+			dt.key, value)
 	}
 	return dt
 }
@@ -67,8 +69,8 @@ func (dt *DateTime) NotEqual(value time.Time) *DateTime {
 //  dt.Gt(time.Unix(0, 1))
 func (dt *DateTime) Gt(value time.Time) *DateTime {
 	if !dt.value.After(value) {
-		dt.chain.fail("\nexpected datetime > then:\n %s\n\nbut got:\n %s",
-			value, dt.value)
+		dt.chain.fail("\nkey:%s\nexpected datetime > then:\n %s\n\nbut got:\n %s",
+			dt.key, value, dt.value)
 	}
 	return dt
 }
@@ -80,8 +82,8 @@ func (dt *DateTime) Gt(value time.Time) *DateTime {
 //  dt.Ge(time.Unix(0, 1))
 func (dt *DateTime) Ge(value time.Time) *DateTime {
 	if !(dt.value.After(value) || dt.value.Equal(value)) {
-		dt.chain.fail("\nexpected datetime >= then:\n %s\n\nbut got:\n %s",
-			value, dt.value)
+		dt.chain.fail("\nkey:%s\nexpected datetime >= then:\n %s\n\nbut got:\n %s",
+			dt.key, value, dt.value)
 	}
 	return dt
 }
@@ -93,8 +95,8 @@ func (dt *DateTime) Ge(value time.Time) *DateTime {
 //  dt.Lt(time.Unix(0, 2))
 func (dt *DateTime) Lt(value time.Time) *DateTime {
 	if !dt.value.Before(value) {
-		dt.chain.fail("\nexpected datetime < then:\n %s\n\nbut got:\n %s",
-			value, dt.value)
+		dt.chain.fail("\nkey:%s\nexpected datetime < then:\n %s\n\nbut got:\n %s",
+			dt.key, value, dt.value)
 	}
 	return dt
 }
@@ -106,8 +108,8 @@ func (dt *DateTime) Lt(value time.Time) *DateTime {
 //  dt.Le(time.Unix(0, 2))
 func (dt *DateTime) Le(value time.Time) *DateTime {
 	if !(dt.value.Before(value) || dt.value.Equal(value)) {
-		dt.chain.fail("\nexpected datetime <= then:\n %s\n\nbut got:\n %s",
-			value, dt.value)
+		dt.chain.fail("\nkey:%s\nexpected datetime <= then:\n %s\n\nbut got:\n %s",
+			dt.key, value, dt.value)
 	}
 	return dt
 }
@@ -122,8 +124,8 @@ func (dt *DateTime) InRange(min, max time.Time) *DateTime {
 	if !((dt.value.After(min) || dt.value.Equal(min)) &&
 		(dt.value.Before(max) || dt.value.Equal(max))) {
 		dt.chain.fail(
-			"\nexpected datetime in range:\n min: %s\n max: %s\n\nbut got: %s",
-			min, max, dt.value)
+			"\nkey:%s\nexpected datetime in range:\n min: %s\n max: %s\n\nbut got: %s",
+			dt.key, min, max, dt.value)
 	}
 	return dt
 }

--- a/datetime.go
+++ b/datetime.go
@@ -43,7 +43,7 @@ func (dt *DateTime) Raw() time.Time {
 //  dt.Equal(time.Unix(0, 1))
 func (dt *DateTime) Equal(value time.Time) *DateTime {
 	if !dt.value.Equal(value) {
-		dt.chain.fail("\nkey:%s\nexpected datetime equal to:\n %s\n\nbut got:\n %s",
+		dt.chain.fail("\nkey:%s\n\nexpected datetime equal to:\n %s\n\nbut got:\n %s",
 			dt.key, value, dt.value)
 	}
 	return dt
@@ -56,7 +56,7 @@ func (dt *DateTime) Equal(value time.Time) *DateTime {
 //  dt.NotEqual(time.Unix(0, 2))
 func (dt *DateTime) NotEqual(value time.Time) *DateTime {
 	if dt.value.Equal(value) {
-		dt.chain.fail("\nkey:%s\nexpected datetime not equal to:\n %s",
+		dt.chain.fail("\nkey:%s\n\nexpected datetime not equal to:\n %s",
 			dt.key, value)
 	}
 	return dt
@@ -69,7 +69,7 @@ func (dt *DateTime) NotEqual(value time.Time) *DateTime {
 //  dt.Gt(time.Unix(0, 1))
 func (dt *DateTime) Gt(value time.Time) *DateTime {
 	if !dt.value.After(value) {
-		dt.chain.fail("\nkey:%s\nexpected datetime > then:\n %s\n\nbut got:\n %s",
+		dt.chain.fail("\nkey:%s\n\nexpected datetime > then:\n %s\n\nbut got:\n %s",
 			dt.key, value, dt.value)
 	}
 	return dt
@@ -82,7 +82,7 @@ func (dt *DateTime) Gt(value time.Time) *DateTime {
 //  dt.Ge(time.Unix(0, 1))
 func (dt *DateTime) Ge(value time.Time) *DateTime {
 	if !(dt.value.After(value) || dt.value.Equal(value)) {
-		dt.chain.fail("\nkey:%s\nexpected datetime >= then:\n %s\n\nbut got:\n %s",
+		dt.chain.fail("\nkey:%s\n\nexpected datetime >= then:\n %s\n\nbut got:\n %s",
 			dt.key, value, dt.value)
 	}
 	return dt
@@ -95,7 +95,7 @@ func (dt *DateTime) Ge(value time.Time) *DateTime {
 //  dt.Lt(time.Unix(0, 2))
 func (dt *DateTime) Lt(value time.Time) *DateTime {
 	if !dt.value.Before(value) {
-		dt.chain.fail("\nkey:%s\nexpected datetime < then:\n %s\n\nbut got:\n %s",
+		dt.chain.fail("\nkey:%s\n\nexpected datetime < then:\n %s\n\nbut got:\n %s",
 			dt.key, value, dt.value)
 	}
 	return dt
@@ -108,7 +108,7 @@ func (dt *DateTime) Lt(value time.Time) *DateTime {
 //  dt.Le(time.Unix(0, 2))
 func (dt *DateTime) Le(value time.Time) *DateTime {
 	if !(dt.value.Before(value) || dt.value.Equal(value)) {
-		dt.chain.fail("\nkey:%s\nexpected datetime <= then:\n %s\n\nbut got:\n %s",
+		dt.chain.fail("\nkey:%s\n\nexpected datetime <= then:\n %s\n\nbut got:\n %s",
 			dt.key, value, dt.value)
 	}
 	return dt
@@ -124,7 +124,7 @@ func (dt *DateTime) InRange(min, max time.Time) *DateTime {
 	if !((dt.value.After(min) || dt.value.Equal(min)) &&
 		(dt.value.Before(max) || dt.value.Equal(max))) {
 		dt.chain.fail(
-			"\nkey:%s\nexpected datetime in range:\n min: %s\n max: %s\n\nbut got: %s",
+			"\nkey:%s\n\nexpected datetime in range:\n min: %s\n max: %s\n\nbut got: %s",
 			dt.key, min, max, dt.value)
 	}
 	return dt

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -14,7 +14,7 @@ func TestDateTimeFailed(t *testing.T) {
 
 	ts := time.Unix(0, 0)
 
-	value := &DateTime{chain, ts}
+	value := &DateTime{chain, ts, ""}
 
 	value.chain.assertFailed(t)
 

--- a/helpers.go
+++ b/helpers.go
@@ -25,16 +25,16 @@ func toString(str interface{}) (s string, ok bool) {
 
 func getPath(chain *chain, value interface{}, path string) *Value {
 	if chain.failed() {
-		return &Value{*chain, nil}
+		return &Value{*chain, nil, ""}
 	}
 
 	result, err := jsonpath.Read(value, path)
 	if err != nil {
 		chain.fail(err.Error())
-		return &Value{*chain, nil}
+		return &Value{*chain, nil, ""}
 	}
 
-	return &Value{*chain, result}
+	return &Value{*chain, result, ""}
 }
 
 func checkSchema(chain *chain, value, schema interface{}) {

--- a/match.go
+++ b/match.go
@@ -64,7 +64,7 @@ func (m *Match) Raw() []string {
 //  m := NewMatch(t, submatches, names)
 //  m.Length().Equal(len(submatches))
 func (m *Match) Length() *Number {
-	return &Number{m.chain, float64(len(m.submatches))}
+	return &Number{m.chain, float64(len(m.submatches)), ""}
 }
 
 // Index returns a new String object that may be used to inspect submatch
@@ -89,9 +89,9 @@ func (m *Match) Index(index int) *String {
 			index,
 			0,
 			len(m.submatches))
-		return &String{m.chain, ""}
+		return &String{m.chain, "", ""}
 	}
-	return &String{m.chain, m.submatches[index]}
+	return &String{m.chain, m.submatches[index], ""}
 }
 
 // Name returns a new String object that may be used to inspect submatch
@@ -115,7 +115,7 @@ func (m *Match) Name(name string) *String {
 			"\nsubmatch name not found:\n %q\n\navailable names:\n%s",
 			name,
 			dumpValue(m.names))
-		return &String{m.chain, ""}
+		return &String{m.chain, "", ""}
 	}
 	return m.Index(index)
 }

--- a/number.go
+++ b/number.go
@@ -59,7 +59,7 @@ func (n *Number) Equal(value interface{}) *Number {
 		return n
 	}
 	if !(n.value == v) {
-		n.chain.fail("\nkey:%s\nexpected number equal to:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number equal to:\n %v\n\nbut got:\n %v",
 			n.key, v, n.value)
 	}
 	return n
@@ -80,7 +80,7 @@ func (n *Number) NotEqual(value interface{}) *Number {
 		return n
 	}
 	if !(n.value != v) {
-		n.chain.fail("\nkey:%s\nexpected number not equal to:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number not equal to:\n %v\n\nbut got:\n %v",
 			v, n.value)
 	}
 	return n
@@ -93,7 +93,7 @@ func (n *Number) NotEqual(value interface{}) *Number {
 //  number.EqualDelta(123.2, 0.3)
 func (n *Number) EqualDelta(value, delta float64) *Number {
 	if math.IsNaN(n.value) || math.IsNaN(value) || math.IsNaN(delta) {
-		n.chain.fail("\nkey:%s\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
 			n.key, value, n.value, delta)
 		return n
 	}
@@ -101,7 +101,7 @@ func (n *Number) EqualDelta(value, delta float64) *Number {
 	diff := (n.value - value)
 
 	if diff < -delta || diff > delta {
-		n.chain.fail("\nkey:%s\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
 			n.key, value, n.value, delta)
 		return n
 	}
@@ -117,7 +117,7 @@ func (n *Number) EqualDelta(value, delta float64) *Number {
 func (n *Number) NotEqualDelta(value, delta float64) *Number {
 	if math.IsNaN(n.value) || math.IsNaN(value) || math.IsNaN(delta) {
 		n.chain.fail(
-			"\nkey:%s\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+			"\nkey:%s\n\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
 			n.key, value, n.value, delta)
 		return n
 	}
@@ -126,7 +126,7 @@ func (n *Number) NotEqualDelta(value, delta float64) *Number {
 
 	if !(diff < -delta || diff > delta) {
 		n.chain.fail(
-			"\nkey:%s\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+			"\nkey:%s\n\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
 			n.key, value, n.value, delta)
 		return n
 	}
@@ -149,7 +149,7 @@ func (n *Number) Gt(value interface{}) *Number {
 		return n
 	}
 	if !(n.value > v) {
-		n.chain.fail("\nkey:%s\nexpected number > then:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number > then:\n %v\n\nbut got:\n %v",
 			n.key, v, n.value)
 	}
 	return n
@@ -170,7 +170,7 @@ func (n *Number) Ge(value interface{}) *Number {
 		return n
 	}
 	if !(n.value >= v) {
-		n.chain.fail("\nkey:%s\nexpected number >= then:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number >= then:\n %v\n\nbut got:\n %v",
 			n.key, v, n.value)
 	}
 	return n
@@ -191,7 +191,7 @@ func (n *Number) Lt(value interface{}) *Number {
 		return n
 	}
 	if !(n.value < v) {
-		n.chain.fail("\nkey:%s\nexpected number < then:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number < then:\n %v\n\nbut got:\n %v",
 			n.key, v, n.value)
 	}
 	return n
@@ -212,7 +212,7 @@ func (n *Number) Le(value interface{}) *Number {
 		return n
 	}
 	if !(n.value <= v) {
-		n.chain.fail("\nkey:%s\nexpected number <= then:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number <= then:\n %v\n\nbut got:\n %v",
 			n.key, v, n.value)
 	}
 	return n
@@ -238,7 +238,7 @@ func (n *Number) InRange(min, max interface{}) *Number {
 		return n
 	}
 	if !(n.value >= a && n.value <= b) {
-		n.chain.fail("\nkey:%s\nexpected number in range:\n [%v; %v]\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\n\nexpected number in range:\n [%v; %v]\n\nbut got:\n %v",
 			n.key, a, b, n.value)
 	}
 	return n

--- a/number.go
+++ b/number.go
@@ -9,6 +9,7 @@ import (
 type Number struct {
 	chain chain
 	value float64
+	key   string
 }
 
 // NewNumber returns a new Number given a reporter used to report
@@ -19,7 +20,7 @@ type Number struct {
 // Example:
 //  number := NewNumber(t, 123.4)
 func NewNumber(reporter Reporter, value float64) *Number {
-	return &Number{makeChain(reporter), value}
+	return &Number{makeChain(reporter), value, ""}
 }
 
 // Raw returns underlying value attached to Number.
@@ -58,8 +59,8 @@ func (n *Number) Equal(value interface{}) *Number {
 		return n
 	}
 	if !(n.value == v) {
-		n.chain.fail("\nexpected number equal to:\n %v\n\nbut got:\n %v",
-			v, n.value)
+		n.chain.fail("\nkey:%s\nexpected number equal to:\n %v\n\nbut got:\n %v",
+			n.key, v, n.value)
 	}
 	return n
 }
@@ -79,7 +80,7 @@ func (n *Number) NotEqual(value interface{}) *Number {
 		return n
 	}
 	if !(n.value != v) {
-		n.chain.fail("\nexpected number not equal to:\n %v\n\nbut got:\n %v",
+		n.chain.fail("\nkey:%s\nexpected number not equal to:\n %v\n\nbut got:\n %v",
 			v, n.value)
 	}
 	return n
@@ -92,16 +93,16 @@ func (n *Number) NotEqual(value interface{}) *Number {
 //  number.EqualDelta(123.2, 0.3)
 func (n *Number) EqualDelta(value, delta float64) *Number {
 	if math.IsNaN(n.value) || math.IsNaN(value) || math.IsNaN(delta) {
-		n.chain.fail("\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
-			value, n.value, delta)
+		n.chain.fail("\nkey:%s\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+			n.key, value, n.value, delta)
 		return n
 	}
 
 	diff := (n.value - value)
 
 	if diff < -delta || diff > delta {
-		n.chain.fail("\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
-			value, n.value, delta)
+		n.chain.fail("\nkey:%s\nexpected number equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+			n.key, value, n.value, delta)
 		return n
 	}
 
@@ -116,8 +117,8 @@ func (n *Number) EqualDelta(value, delta float64) *Number {
 func (n *Number) NotEqualDelta(value, delta float64) *Number {
 	if math.IsNaN(n.value) || math.IsNaN(value) || math.IsNaN(delta) {
 		n.chain.fail(
-			"\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
-			value, n.value, delta)
+			"\nkey:%s\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+			n.key, value, n.value, delta)
 		return n
 	}
 
@@ -125,8 +126,8 @@ func (n *Number) NotEqualDelta(value, delta float64) *Number {
 
 	if !(diff < -delta || diff > delta) {
 		n.chain.fail(
-			"\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
-			value, n.value, delta)
+			"\nkey:%s\nexpected number not equal to:\n %v\n\nbut got:\n %v\n\ndelta:\n %v",
+			n.key, value, n.value, delta)
 		return n
 	}
 
@@ -148,8 +149,8 @@ func (n *Number) Gt(value interface{}) *Number {
 		return n
 	}
 	if !(n.value > v) {
-		n.chain.fail("\nexpected number > then:\n %v\n\nbut got:\n %v",
-			v, n.value)
+		n.chain.fail("\nkey:%s\nexpected number > then:\n %v\n\nbut got:\n %v",
+			n.key, v, n.value)
 	}
 	return n
 }
@@ -169,8 +170,8 @@ func (n *Number) Ge(value interface{}) *Number {
 		return n
 	}
 	if !(n.value >= v) {
-		n.chain.fail("\nexpected number >= then:\n %v\n\nbut got:\n %v",
-			v, n.value)
+		n.chain.fail("\nkey:%s\nexpected number >= then:\n %v\n\nbut got:\n %v",
+			n.key, v, n.value)
 	}
 	return n
 }
@@ -190,8 +191,8 @@ func (n *Number) Lt(value interface{}) *Number {
 		return n
 	}
 	if !(n.value < v) {
-		n.chain.fail("\nexpected number < then:\n %v\n\nbut got:\n %v",
-			v, n.value)
+		n.chain.fail("\nkey:%s\nexpected number < then:\n %v\n\nbut got:\n %v",
+			n.key, v, n.value)
 	}
 	return n
 }
@@ -211,8 +212,8 @@ func (n *Number) Le(value interface{}) *Number {
 		return n
 	}
 	if !(n.value <= v) {
-		n.chain.fail("\nexpected number <= then:\n %v\n\nbut got:\n %v",
-			v, n.value)
+		n.chain.fail("\nkey:%s\nexpected number <= then:\n %v\n\nbut got:\n %v",
+			n.key, v, n.value)
 	}
 	return n
 }
@@ -237,8 +238,8 @@ func (n *Number) InRange(min, max interface{}) *Number {
 		return n
 	}
 	if !(n.value >= a && n.value <= b) {
-		n.chain.fail("\nexpected number in range:\n [%v; %v]\n\nbut got:\n %v",
-			a, b, n.value)
+		n.chain.fail("\nkey:%s\nexpected number in range:\n [%v; %v]\n\nbut got:\n %v",
+			n.key, a, b, n.value)
 	}
 	return n
 }

--- a/number_test.go
+++ b/number_test.go
@@ -12,7 +12,7 @@ func TestNumberFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	value := &Number{chain, 0}
+	value := &Number{chain, 0, ""}
 
 	value.chain.assertFailed(t)
 

--- a/object.go
+++ b/object.go
@@ -9,6 +9,7 @@ import (
 type Object struct {
 	chain chain
 	value map[string]interface{}
+	key   string
 }
 
 // NewObject returns a new Object given a reporter used to report failures
@@ -26,7 +27,7 @@ func NewObject(reporter Reporter, value map[string]interface{}) *Object {
 	} else {
 		value, _ = canonMap(&chain, value)
 	}
-	return &Object{chain, value}
+	return &Object{chain, value, ""}
 }
 
 // Raw returns underlying value attached to Object.
@@ -60,7 +61,7 @@ func (o *Object) Keys() *Array {
 	for k := range o.value {
 		keys = append(keys, k)
 	}
-	return &Array{o.chain, keys}
+	return &Array{o.chain, keys, o.key}
 }
 
 // Values returns a new Array object that may be used to inspect objects values.
@@ -73,7 +74,7 @@ func (o *Object) Values() *Array {
 	for _, v := range o.value {
 		values = append(values, v)
 	}
-	return &Array{o.chain, values}
+	return &Array{o.chain, values, o.key}
 }
 
 // Value returns a new Value object that may be used to inspect single value
@@ -87,9 +88,9 @@ func (o *Object) Value(key string) *Value {
 	if !ok {
 		o.chain.fail("\nexpected object containing key '%s', but got:\n%s",
 			key, dumpValue(o.value))
-		return &Value{o.chain, nil}
+		return &Value{o.chain, nil, ""}
 	}
-	return &Value{o.chain, value}
+	return &Value{o.chain, value, ""}
 }
 
 // Empty succeeds if object is empty.

--- a/object.go
+++ b/object.go
@@ -88,9 +88,9 @@ func (o *Object) Value(key string) *Value {
 	if !ok {
 		o.chain.fail("\nexpected object containing key '%s', but got:\n%s",
 			key, dumpValue(o.value))
-		return &Value{o.chain, nil, ""}
+		return &Value{o.chain, nil, key}
 	}
-	return &Value{o.chain, value, ""}
+	return &Value{o.chain, value, key}
 }
 
 // Empty succeeds if object is empty.

--- a/object_test.go
+++ b/object_test.go
@@ -11,7 +11,7 @@ func TestObjectFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	value := &Object{chain, nil}
+	value := &Object{chain, nil, ""}
 
 	value.chain.assertFailed(t)
 

--- a/response.go
+++ b/response.go
@@ -134,9 +134,9 @@ func (r *Response) RoundTripTime() *Duration {
 // Deprecated: use RoundTripTime instead.
 func (r *Response) Duration() *Number {
 	if r.rtt == nil {
-		return &Number{r.chain, 0}
+		return &Number{r.chain, 0, ""}
 	}
-	return &Number{r.chain, float64(*r.rtt)}
+	return &Number{r.chain, float64(*r.rtt), ""}
 }
 
 // Status succeeds if response contains given status code.
@@ -224,7 +224,7 @@ func (r *Response) Headers() *Object {
 	if !r.chain.failed() {
 		value, _ = canonMap(&r.chain, r.resp.Header)
 	}
-	return &Object{r.chain, value}
+	return &Object{r.chain, value, ""}
 }
 
 // Header returns a new String object that may be used to inspect given header.
@@ -238,7 +238,7 @@ func (r *Response) Header(header string) *String {
 	if !r.chain.failed() {
 		value = r.resp.Header.Get(header)
 	}
-	return &String{r.chain, value}
+	return &String{r.chain, value, ""}
 }
 
 // Cookies returns a new Array object with all cookie names set by this response.
@@ -253,13 +253,13 @@ func (r *Response) Header(header string) *String {
 //  resp.Cookies().Contains("session")
 func (r *Response) Cookies() *Array {
 	if r.chain.failed() {
-		return &Array{r.chain, nil}
+		return &Array{r.chain, nil, ""}
 	}
 	names := []interface{}{}
 	for _, c := range r.cookies {
 		names = append(names, c.Name)
 	}
-	return &Array{r.chain, names}
+	return &Array{r.chain, names, ""}
 }
 
 // Cookie returns a new Cookie object that may be used to inspect given cookie
@@ -313,7 +313,7 @@ func (r *Response) Websocket() *Websocket {
 //  resp.Body().NotEmpty()
 //  resp.Body().Length().Equal(100)
 func (r *Response) Body() *String {
-	return &String{r.chain, string(r.content)}
+	return &String{r.chain, string(r.content), ""}
 }
 
 // NoContent succeeds if response contains empty Content-Type header and
@@ -390,7 +390,7 @@ func (r *Response) Text(opts ...ContentOpts) *String {
 		content = string(r.content)
 	}
 
-	return &String{r.chain, content}
+	return &String{r.chain, content, ""}
 }
 
 // Form returns a new Object that may be used to inspect form contents
@@ -408,7 +408,7 @@ func (r *Response) Text(opts ...ContentOpts) *String {
 //  }).Value("foo").Equal("bar")
 func (r *Response) Form(opts ...ContentOpts) *Object {
 	object := r.getForm(opts...)
-	return &Object{r.chain, object}
+	return &Object{r.chain, object, ""}
 }
 
 func (r *Response) getForm(opts ...ContentOpts) map[string]interface{} {
@@ -445,7 +445,7 @@ func (r *Response) getForm(opts ...ContentOpts) map[string]interface{} {
 //  }).Array.Elements("foo", "bar")
 func (r *Response) JSON(opts ...ContentOpts) *Value {
 	value := r.getJSON(opts...)
-	return &Value{r.chain, value}
+	return &Value{r.chain, value, ""}
 }
 
 func (r *Response) getJSON(opts ...ContentOpts) interface{} {
@@ -485,7 +485,7 @@ func (r *Response) getJSON(opts ...ContentOpts) interface{} {
 //  }).Array.Elements("foo", "bar")
 func (r *Response) JSONP(callback string, opts ...ContentOpts) *Value {
 	value := r.getJSONP(callback, opts...)
-	return &Value{r.chain, value}
+	return &Value{r.chain, value, ""}
 }
 
 var (

--- a/string.go
+++ b/string.go
@@ -113,7 +113,7 @@ func (s *String) NotEmpty() *String {
 //  str.Equal("Hello")
 func (s *String) Equal(value string) *String {
 	if !(s.value == value) {
-		s.chain.fail("\nkey:%s\nexpected string equal to:\n %q\n\nbut got:\n %q",
+		s.chain.fail("\nkey:%s\n\nexpected string equal to:\n %q\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
 	return s
@@ -126,7 +126,7 @@ func (s *String) Equal(value string) *String {
 //  str.NotEqual("Goodbye")
 func (s *String) NotEqual(value string) *String {
 	if !(s.value != value) {
-		s.chain.fail("\nkey:%s\nexpected string not equal to:\n %q",
+		s.chain.fail("\nkey:%s\n\nexpected string not equal to:\n %q",
 			s.key, value)
 	}
 	return s
@@ -141,7 +141,7 @@ func (s *String) NotEqual(value string) *String {
 func (s *String) EqualFold(value string) *String {
 	if !strings.EqualFold(s.value, value) {
 		s.chain.fail(
-			"\nkey:%s\nexpected string equal to (case-insensitive):\n %q\n\nbut got:\n %q",
+			"\nkey:%s\n\nexpected string equal to (case-insensitive):\n %q\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
 	return s
@@ -156,7 +156,7 @@ func (s *String) EqualFold(value string) *String {
 func (s *String) NotEqualFold(value string) *String {
 	if strings.EqualFold(s.value, value) {
 		s.chain.fail(
-			"\nkey:%s\nexpected string not equal to (case-insensitive):\n %q\n\nbut got:\n %q",
+			"\nkey:%s\n\nexpected string not equal to (case-insensitive):\n %q\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
 	return s
@@ -170,7 +170,7 @@ func (s *String) NotEqualFold(value string) *String {
 func (s *String) Contains(value string) *String {
 	if !strings.Contains(s.value, value) {
 		s.chain.fail(
-			"\nkey:%s\nexpected string containing substring:\n %q\n\nbut got:\n %q",
+			"\nkey:%s\n\nexpected string containing substring:\n %q\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
 	return s
@@ -184,7 +184,7 @@ func (s *String) Contains(value string) *String {
 func (s *String) NotContains(value string) *String {
 	if strings.Contains(s.value, value) {
 		s.chain.fail(
-			"\nkey:%s\nexpected string not containing substring:\n %q\n\nbut got:\n %q",
+			"\nkey:%s\n\nexpected string not containing substring:\n %q\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
 	return s
@@ -199,7 +199,7 @@ func (s *String) NotContains(value string) *String {
 func (s *String) ContainsFold(value string) *String {
 	if !strings.Contains(strings.ToLower(s.value), strings.ToLower(value)) {
 		s.chain.fail(
-			"\nkey:%s\nexpected string containing substring (case-insensitive):\n %q"+
+			"\nkey:%s\n\nexpected string containing substring (case-insensitive):\n %q"+
 				"\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
@@ -215,7 +215,7 @@ func (s *String) ContainsFold(value string) *String {
 func (s *String) NotContainsFold(value string) *String {
 	if strings.Contains(strings.ToLower(s.value), strings.ToLower(value)) {
 		s.chain.fail(
-			"\nkey:%s\nexpected string not containing substring (case-insensitive):\n %q"+
+			"\nkey:%s\n\nexpected string not containing substring (case-insensitive):\n %q"+
 				"\n\nbut got:\n %q",
 			s.key, value, s.value)
 	}
@@ -251,7 +251,7 @@ func (s *String) Match(re string) *Match {
 
 	m := r.FindStringSubmatch(s.value)
 	if m == nil {
-		s.chain.fail("\nkey:%s\nexpected string matching regexp:\n `%s`\n\nbut got:\n %q",
+		s.chain.fail("\nkey:%s\n\nexpected string matching regexp:\n `%s`\n\nbut got:\n %q",
 			s.key, re, s.value)
 		return makeMatch(s.chain, nil, nil)
 	}
@@ -283,7 +283,7 @@ func (s *String) MatchAll(re string) []Match {
 
 	matches := r.FindAllStringSubmatch(s.value, -1)
 	if matches == nil {
-		s.chain.fail("\nkey:%s\nexpected string matching regexp:\n `%s`\n\nbut got:\n %q",
+		s.chain.fail("\nkey:%s\n\nexpected string matching regexp:\n `%s`\n\nbut got:\n %q",
 			s.key, re, s.value)
 		return []Match{}
 	}
@@ -315,7 +315,7 @@ func (s *String) NotMatch(re string) *String {
 	}
 
 	if r.MatchString(s.value) {
-		s.chain.fail("\nkey:%s\nexpected string not matching regexp:\n `%s`\n\nbut got:\n %q",
+		s.chain.fail("\nkey:%s\n\nexpected string not matching regexp:\n `%s`\n\nbut got:\n %q",
 			s.key, re, s.value)
 		return s
 	}

--- a/string_test.go
+++ b/string_test.go
@@ -12,7 +12,7 @@ func TestStringFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	value := &String{chain, ""}
+	value := &String{chain, "", ""}
 
 	value.Path("$").chain.assertFailed(t)
 	value.Schema("")

--- a/value.go
+++ b/value.go
@@ -10,6 +10,7 @@ import (
 type Value struct {
 	chain chain
 	value interface{}
+	key   string
 }
 
 // NewValue returns a new Value given a reporter used to report failures
@@ -40,7 +41,7 @@ func NewValue(reporter Reporter, value interface{}) *Value {
 	if value != nil {
 		value, _ = canonValue(&chain, value)
 	}
-	return &Value{chain, value}
+	return &Value{chain, value, ""}
 }
 
 // Raw returns underlying value attached to Value.
@@ -133,10 +134,11 @@ func (v *Value) Schema(schema interface{}) *Value {
 func (v *Value) Object() *Object {
 	data, ok := v.value.(map[string]interface{})
 	if !ok {
-		v.chain.fail("\nexpected object value (map or struct), but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected object value (map or struct), but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
-	return &Object{v.chain, data}
+	return &Object{v.chain, data, v.key}
 }
 
 // Array returns a new Array attached to underlying value.
@@ -150,10 +152,11 @@ func (v *Value) Object() *Object {
 func (v *Value) Array() *Array {
 	data, ok := v.value.([]interface{})
 	if !ok {
-		v.chain.fail("\nexpected array value, but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected array value, but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
-	return &Array{v.chain, data}
+	return &Array{v.chain, data, v.key}
 }
 
 // String returns a new String attached to underlying value.
@@ -167,10 +170,11 @@ func (v *Value) Array() *Array {
 func (v *Value) String() *String {
 	data, ok := v.value.(string)
 	if !ok {
-		v.chain.fail("\nexpected string value, but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected string value, but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
-	return &String{v.chain, data}
+	return &String{v.chain, data, v.key}
 }
 
 // Number returns a new Number attached to underlying value.
@@ -184,10 +188,11 @@ func (v *Value) String() *String {
 func (v *Value) Number() *Number {
 	data, ok := v.value.(float64)
 	if !ok {
-		v.chain.fail("\nexpected numeric value, but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected numeric value, but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
-	return &Number{v.chain, data}
+	return &Number{v.chain, data, v.key}
 }
 
 // Boolean returns a new Boolean attached to underlying value.
@@ -201,10 +206,11 @@ func (v *Value) Number() *Number {
 func (v *Value) Boolean() *Boolean {
 	data, ok := v.value.(bool)
 	if !ok {
-		v.chain.fail("\nexpected boolean value, but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected boolean value, but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
-	return &Boolean{v.chain, data}
+	return &Boolean{v.chain, data, v.key}
 }
 
 // Null succeeds if value is nil.
@@ -221,7 +227,8 @@ func (v *Value) Boolean() *Boolean {
 //  value.Null()
 func (v *Value) Null() *Value {
 	if v.value != nil {
-		v.chain.fail("\nexpected nil value, but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected nil value, but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
 	return v
@@ -241,7 +248,8 @@ func (v *Value) Null() *Value {
 //  value.Null()
 func (v *Value) NotNull() *Value {
 	if v.value == nil {
-		v.chain.fail("\nexpected non-nil value, but got:\n%s",
+		v.chain.fail("\nkey:%s\nexpected non-nil value, but got:\n%s",
+			v.key,
 			dumpValue(v.value))
 	}
 	return v
@@ -259,7 +267,8 @@ func (v *Value) Equal(value interface{}) *Value {
 		return v
 	}
 	if !reflect.DeepEqual(expected, v.value) {
-		v.chain.fail("\nexpected value equal to:\n%s\n\nbut got:\n%s\n\ndiff:\n%s",
+		v.chain.fail("\nkey:%s\nexpected value equal to:\n%s\n\nbut got:\n%s\n\ndiff:\n%s",
+			v.key,
 			dumpValue(expected),
 			dumpValue(v.value),
 			diffValues(expected, v.value))
@@ -279,7 +288,8 @@ func (v *Value) NotEqual(value interface{}) *Value {
 		return v
 	}
 	if reflect.DeepEqual(expected, v.value) {
-		v.chain.fail("\nexpected value not equal to:\n%s",
+		v.chain.fail("\nkey:%s\nexpected value not equal to:\n%s",
+			v.key,
 			dumpValue(expected))
 	}
 	return v

--- a/value.go
+++ b/value.go
@@ -134,7 +134,7 @@ func (v *Value) Schema(schema interface{}) *Value {
 func (v *Value) Object() *Object {
 	data, ok := v.value.(map[string]interface{})
 	if !ok {
-		v.chain.fail("\nkey:%s\nexpected object value (map or struct), but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected object value (map or struct), but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -152,7 +152,7 @@ func (v *Value) Object() *Object {
 func (v *Value) Array() *Array {
 	data, ok := v.value.([]interface{})
 	if !ok {
-		v.chain.fail("\nkey:%s\nexpected array value, but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected array value, but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -170,7 +170,7 @@ func (v *Value) Array() *Array {
 func (v *Value) String() *String {
 	data, ok := v.value.(string)
 	if !ok {
-		v.chain.fail("\nkey:%s\nexpected string value, but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected string value, but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -188,7 +188,7 @@ func (v *Value) String() *String {
 func (v *Value) Number() *Number {
 	data, ok := v.value.(float64)
 	if !ok {
-		v.chain.fail("\nkey:%s\nexpected numeric value, but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected numeric value, but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -206,7 +206,7 @@ func (v *Value) Number() *Number {
 func (v *Value) Boolean() *Boolean {
 	data, ok := v.value.(bool)
 	if !ok {
-		v.chain.fail("\nkey:%s\nexpected boolean value, but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected boolean value, but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -227,7 +227,7 @@ func (v *Value) Boolean() *Boolean {
 //  value.Null()
 func (v *Value) Null() *Value {
 	if v.value != nil {
-		v.chain.fail("\nkey:%s\nexpected nil value, but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected nil value, but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -248,7 +248,7 @@ func (v *Value) Null() *Value {
 //  value.Null()
 func (v *Value) NotNull() *Value {
 	if v.value == nil {
-		v.chain.fail("\nkey:%s\nexpected non-nil value, but got:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected non-nil value, but got:\n%s",
 			v.key,
 			dumpValue(v.value))
 	}
@@ -267,7 +267,7 @@ func (v *Value) Equal(value interface{}) *Value {
 		return v
 	}
 	if !reflect.DeepEqual(expected, v.value) {
-		v.chain.fail("\nkey:%s\nexpected value equal to:\n%s\n\nbut got:\n%s\n\ndiff:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected value equal to:\n%s\n\nbut got:\n%s\n\ndiff:\n%s",
 			v.key,
 			dumpValue(expected),
 			dumpValue(v.value),
@@ -288,7 +288,7 @@ func (v *Value) NotEqual(value interface{}) *Value {
 		return v
 	}
 	if reflect.DeepEqual(expected, v.value) {
-		v.chain.fail("\nkey:%s\nexpected value not equal to:\n%s",
+		v.chain.fail("\nkey:%s\n\nexpected value not equal to:\n%s",
 			v.key,
 			dumpValue(expected))
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -15,7 +15,7 @@ func TestValueFailed(t *testing.T) {
 
 	chain.fail("fail")
 
-	value := &Value{chain, nil}
+	value := &Value{chain, nil, ""}
 
 	value.chain.assertFailed(t)
 

--- a/websocket_message.go
+++ b/websocket_message.go
@@ -247,7 +247,7 @@ func (m *WebsocketMessage) checkClosed(where string) bool {
 //  msg.Body().NotEmpty()
 //  msg.Body().Length().Equal(100)
 func (m *WebsocketMessage) Body() *String {
-	return &String{m.chain, string(m.content)}
+	return &String{m.chain, string(m.content), ""}
 }
 
 // NoContent succeeds if WebSocket message has no content (is empty).
@@ -280,7 +280,7 @@ func (m *WebsocketMessage) NoContent() *WebsocketMessage {
 //  msg := conn.Expect()
 //  msg.JSON().Array().Elements("foo", "bar")
 func (m *WebsocketMessage) JSON() *Value {
-	return &Value{m.chain, m.getJSON()}
+	return &Value{m.chain, m.getJSON(), ""}
 }
 
 func (m *WebsocketMessage) getJSON() interface{} {


### PR DESCRIPTION
#### What am I using?

- Web framework: Gin
- Ide: vscode

#### Go version 
go 1.16+

#### Repositorie
[https://github.com/snowlyg/iris-admin](https://github.com/snowlyg/iris-admin)


When I use [https://github.com/snowlyg/httptest](https://github.com/snowlyg/httptest) to test  HTTP API and the HTTP response object or array data, I can't know the fail is which key.

```
func (rks ResponseKeys) Test(object *httpexpect.Object) {
	for _, rk := range rks {
		zap_server.ZAPLOG.Info(rk.Key)
		// to sign the test data key name
		if rk.Value == nil {
			continue
		}
		switch reflect.TypeOf(rk.Value).String() {
		case "string":
			if strings.ToLower(rk.Type) == "notempty" {
				object.Value(rk.Key).String().NotEmpty()
			} else {
				object.Value(rk.Key).String().Equal(rk.Value.(string))
			}
		case "float64":
			if strings.ToLower(rk.Type) == "ge" {
				object.Value(rk.Key).Number().Ge(rk.Value.(float64))
			} else {
				object.Value(rk.Key).Number().Equal(rk.Value.(float64))
			}
		case "uint":
			if strings.ToLower(rk.Type) == "ge" {
				object.Value(rk.Key).Number().Ge(rk.Value.(uint))
			} else {
				object.Value(rk.Key).Number().Equal(rk.Value.(uint))
			}
		case "int":
			if strings.ToLower(rk.Type) == "ge" {
				object.Value(rk.Key).Number().Ge(rk.Value.(int))
			} else {
				object.Value(rk.Key).Number().Equal(rk.Value.(int))
			}
		case "[]base.ResponseKeys":
			if strings.ToLower(rk.Type) == "empty" {
				object.Value(rk.Key).Array().Empty()
				continue
			}
```
![image](https://user-images.githubusercontent.com/45998760/167582980-ae19293f-c944-4086-93be-3f9e9f315ab1.png)

I will add a key to the fail message report like below :

![image](https://user-images.githubusercontent.com/45998760/167581171-ca39fd0e-42c6-4b6f-a346-50c19c969424.png) #110 