### PR TITLE
tests: fix expected filename in TestRequestBodyMultipartFile

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1211,7 +1212,7 @@ func TestRequestBodyMultipartFile(t *testing.T) {
 
 	part2, _ := reader.NextPart()
 	assert.Equal(t, "b", part2.FormName())
-	assert.Equal(t, filename2, part2.FileName())
+	assert.Equal(t, filepath.Base(filename2), part2.FileName())
 	b2, _ := ioutil.ReadAll(part2)
 	assert.Equal(t, "2", string(b2))
 


### PR DESCRIPTION
currently TestRequestBodyMultipartFile expect the filename given by

func (*multipartPart) FileName() string

to be a fullpath in one of the test cases, however the documentation
states that:

> the filename is passed through filepath.Base (which is platform
> dependent) before being returned.

then the test fails.

This change fix the expected filename for this test, using the same
filepath.Base function.

Fixes: #103