### PR TITLE
Fix a test error in go1.17: expected multipart filename should not include its directory path

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1211,7 +1212,7 @@ func TestRequestBodyMultipartFile(t *testing.T) {
 
 	part2, _ := reader.NextPart()
 	assert.Equal(t, "b", part2.FormName())
-	assert.Equal(t, filename2, part2.FileName())
+	assert.Equal(t, filepath.Base(filename2), part2.FileName())
 	b2, _ := ioutil.ReadAll(part2)
 	assert.Equal(t, "2", string(b2))
 


### PR DESCRIPTION
This repo depends on a version of [valyala/fasthttp](https://github.com/valyala/fasthttp) that contains a critical security vulnerability: https://www.cve.org/CVERecord?id=CVE-2022-21221.

`dependabot` has a bump of the version but the test was failing due to a change in [multipart filename in go 1.17](https://cs.opensource.google/go/go/+/dev.boringcrypto.go1.17:src/mime/multipart/multipart.go;l=84).

This PR fixes this test failure and hope the vulnerability can be fixed as well.



