### PR TITLE
Add retry sleep with context

### DIFF
--- a/e2e_context_test.go
+++ b/e2e_context_test.go
@@ -501,7 +501,7 @@ func TestContextPerRequestRetry(t *testing.T) {
 	t.Run("cancelled on second retry attempt", func(t *testing.T) {
 		var callCount int
 		var isCtxCancelled bool
-		ctxCancellation := make(chan bool, 1) // To cancel context after frist retry attempt
+		ctxCancellation := make(chan bool, 1) // To cancel context after first retry attempt
 		retryDelayDuration := 5 * time.Second
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/e2e_context_test.go
+++ b/e2e_context_test.go
@@ -394,7 +394,7 @@ func TestContextPerRequestWithTimeoutCancelledByContext(t *testing.T) {
 	assert.True(t, suppressor.expErrorOccurred)
 }
 
-func TestContextPerRequestWithRetryCancelledByContext(t *testing.T) {
+func TestContextPerRequestRetryCancelledByContext(t *testing.T) {
 	var callCount int
 	var isConfigCtxCancelled bool
 	delayDuration := TimeOutDuration / 2

--- a/e2e_context_test.go
+++ b/e2e_context_test.go
@@ -420,13 +420,13 @@ func TestContextPerRequestRetry(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go func(fn context.CancelFunc) {
+		go func() {
 			time.Sleep(ctxCancellationSleepDuration)
-			fn()
+			cancel()
 			m.Lock()
 			defer m.Unlock()
 			isCtxCancelled = true
-		}(cancel)
+		}()
 
 		// Config with all error
 		suppressor := newExpErrorSuppressor(t,
@@ -467,13 +467,13 @@ func TestContextPerRequestRetry(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go func(fn context.CancelFunc) {
+		go func() {
 			time.Sleep(ctxCancellationSleepDuration)
-			fn()
+			cancel()
 			m.Lock()
 			defer m.Unlock()
 			isCtxCancelled = true
-		}(cancel)
+		}()
 
 		// Config with context cancelled error
 		suppressor := newExpErrorSuppressor(t,
@@ -519,13 +519,13 @@ func TestContextPerRequestRetry(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go func(fn context.CancelFunc) {
+		go func() {
 			<-ctxCancellation
-			fn()
+			cancel()
 			m.Lock()
 			defer m.Unlock()
 			isCtxCancelled = true
-		}(cancel)
+		}()
 
 		// Config with context cancelled error
 		suppressor := newExpErrorSuppressor(t,

--- a/e2e_context_test.go
+++ b/e2e_context_test.go
@@ -502,7 +502,7 @@ func TestContextPerRequestRetry(t *testing.T) {
 		var callCount int
 		var isCtxCancelled bool
 		ctxCancellation := make(chan bool, 1) // To cancel context after first retry attempt
-		retryDelayDuration := 5 * time.Second
+		retryDelayDuration := 1 * time.Second
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			m.Lock()

--- a/request.go
+++ b/request.go
@@ -1927,7 +1927,7 @@ func (r *Request) retryRequest(reqFunc func() (*http.Response, error)) (
 		if configCtx := r.config.Context; configCtx != nil {
 			select {
 			case <-configCtx.Done():
-				return nil, elapsed, r.httpReq.Context().Err()
+				return nil, elapsed, configCtx.Err()
 			case <-r.sleepFn(delay):
 			}
 		} else {

--- a/request_test.go
+++ b/request_test.go
@@ -2888,6 +2888,8 @@ func TestRequestRetry(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately to trigger error
 
+		start := time.Now()
+
 		req := NewRequest(config, http.MethodPost, "/url").
 			WithText("test body").
 			WithRetryPolicy(RetryAllErrors).
@@ -2895,10 +2897,13 @@ func TestRequestRetry(t *testing.T) {
 			WithContext(ctx)
 		req.chain.assertOK(t)
 
+		elapsed := time.Since(start)
+
 		resp := req.Expect()
 		resp.chain.assertFailed(t)
 
 		// Should not retry
 		assert.Equal(t, 1, callCount)
+		assert.Equal(t, time.Duration(0), elapsed.Round(req.minRetryDelay))
 	})
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2888,22 +2888,17 @@ func TestRequestRetry(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately to trigger error
 
-		start := time.Now()
-
 		req := NewRequest(config, http.MethodPost, "/url").
 			WithText("test body").
 			WithRetryPolicy(RetryAllErrors).
 			WithMaxRetries(1).
-			WithContext(ctx)
+			WithContext(ctx).WithRetryDelay(1*time.Minute, 5*time.Minute)
 		req.chain.assertOK(t)
-
-		elapsed := time.Since(start)
 
 		resp := req.Expect()
 		resp.chain.assertFailed(t)
 
 		// Should not retry
 		assert.Equal(t, 1, callCount)
-		assert.Equal(t, time.Duration(0), elapsed.Round(req.minRetryDelay))
 	})
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2892,7 +2892,6 @@ func TestRequestRetry(t *testing.T) {
 			WithText("test body").
 			WithRetryPolicy(RetryAllErrors).
 			WithMaxRetries(1).
-			WithRetryDelay(100*time.Millisecond, 300*time.Millisecond).
 			WithContext(ctx)
 		req.chain.assertOK(t)
 

--- a/request_test.go
+++ b/request_test.go
@@ -2892,7 +2892,8 @@ func TestRequestRetry(t *testing.T) {
 			WithText("test body").
 			WithRetryPolicy(RetryAllErrors).
 			WithMaxRetries(1).
-			WithContext(ctx).WithRetryDelay(1*time.Minute, 5*time.Minute)
+			WithContext(ctx).
+			WithRetryDelay(1*time.Minute, 5*time.Minute)
 		req.chain.assertOK(t)
 
 		resp := req.Expect()


### PR DESCRIPTION
Issue: https://github.com/gavv/httpexpect/issues/163

Changes:

- Update `sleepFn` to return `<-chan time.Time`
- Update unit test
- Update e2e test