### PR TITLE
Add test cases for request.go file

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -2197,17 +2197,16 @@ func TestValidationFailures(t *testing.T) {
 
 	t.Run("setupRedirect - redirect policy", func(t *testing.T) {
 		req := NewRequest(config, "METHOD", "/")
-		req.config.Client = nil
-		req.redirectPolicy = FollowAllRedirects
+		req.config.Client = &mockClient{}
+		req.WithRedirectPolicy(FollowAllRedirects)
 		req.Expect() // calls setupRedirect indirectly
 		req.chain.assertFailed(t)
 	})
 
 	t.Run("setupRedirect - maxRedirects is not -1", func(t *testing.T) {
 		req := NewRequest(config, "METHOD", "/")
-		req.config.Client = nil
-		req.redirectPolicy = defaultRedirectPolicy
-		req.maxRedirects = 0
+		req.config.Client = &mockClient{}
+		req.WithMaxRedirects(0)
 		req.Expect() // calls setupRedirect indirectly
 		req.chain.assertFailed(t)
 	})

--- a/request_test.go
+++ b/request_test.go
@@ -2201,12 +2201,6 @@ func TestValidationFailures(t *testing.T) {
 		req.Expect() // calls setupRedirect indirectly
 		req.chain.assertFailed(t)
 	})
-
-	t.Run("WithContext", func(t *testing.T) {
-		req := NewRequest(config, "METHOD", "/")
-		req.WithContext(nil)
-		req.chain.assertFailed(t)
-	})
 }
 
 func TestWithRetryDelay(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -2200,6 +2200,50 @@ func TestValidationFailures(t *testing.T) {
 		req.WithFile("test-key", "test-path", nil, nil)
 		req.chain.assertFailed(t)
 	})
+
+	t.Run("setupRedirect - http client is nil and redirect policy is not defaultRedirectPolicy", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.config.Client = nil
+		req.redirectPolicy = FollowAllRedirects
+		req.setupRedirects()
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("setupRedirect - http client is nil and maxRedirects is not -1", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.config.Client = nil
+		req.redirectPolicy = defaultRedirectPolicy
+		req.maxRedirects = 0
+		req.setupRedirects()
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("encodeWebsocketRequest", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.bodySetter = "some value"
+		req.encodeWebsocketRequest()
+		req.chain.assertFailed(t)
+	})
+}
+
+func TestEncodeWebsocketRequest(t *testing.T) {
+	factory := DefaultRequestFactory{}
+
+	client := &mockClient{}
+
+	reporter := newMockReporter(t)
+
+	config := Config{
+		RequestFactory: factory,
+		Client:         client,
+		Reporter:       reporter,
+	}
+
+	req := NewRequest(config, "METHOD", "/")
+	req.httpReq.URL.Scheme = "https"
+	actual := req.encodeWebsocketRequest()
+	assert.Equal(t, "wss", req.httpReq.URL.Scheme)
+	assert.True(t, actual)
 }
 
 func TestWithRetryDelay(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -2202,6 +2202,25 @@ func TestValidationFailures(t *testing.T){
 	})
 }
 
+func TestWithRetryDelay(t *testing.T){
+	factory := DefaultRequestFactory{}
+
+	client := &mockClient{}
+
+	reporter := newMockReporter(t)
+
+	config := Config{
+		RequestFactory: factory,
+		Client:         client,
+		Reporter:       reporter,
+	}
+
+	req := NewRequest(config, "METHOD", "/")
+	req.WithRetryDelay(5, 10)
+	assert.Equal(t, time.Duration(5), req.minRetryDelay)
+	assert.Equal(t, time.Duration(10), req.maxRetryDelay)
+}
+
 // mockTransportRedirect mocks a transport that implements RoundTripper
 //
 // When tripCount < maxRedirect,

--- a/request_test.go
+++ b/request_test.go
@@ -2997,6 +2997,7 @@ func TestRequestRetry(t *testing.T) {
 				totalSleepTime += d
 				return time.After(0)
 			}
+
 			req.chain.assertNotFailed(t)
 
 			resp := req.Expect().
@@ -3006,5 +3007,41 @@ func TestRequestRetry(t *testing.T) {
 			// Should retry with delay
 			assert.Equal(t, int64(100+200+300), totalSleepTime.Milliseconds())
 		})
+	})
+
+	t.Run("cancelled retries", func(t *testing.T) {
+		callCount := 0
+
+		client := newHTTPErrClient(func(req *http.Request) {
+			callCount++
+
+			assert.Error(t, req.Context().Err(), context.Canceled.Error())
+
+			b, err := ioutil.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, "test body", string(b))
+		})
+
+		config := Config{
+			Client:   client,
+			Reporter: reporter,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately to trigger error
+
+		req := NewRequest(config, http.MethodPost, "/url").
+			WithText("test body").
+			WithRetryPolicy(RetryAllErrors).
+			WithMaxRetries(1).
+			WithContext(ctx).
+			WithRetryDelay(1*time.Minute, 5*time.Minute)
+		req.chain.assertNotFailed(t)
+
+		resp := req.Expect()
+		resp.chain.assertFailed(t)
+
+		// Should not retry
+		assert.Equal(t, 1, callCount)
 	})
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2147,12 +2147,6 @@ func TestValidationFailures(t *testing.T) {
 		req.chain.assertFailed(t)
 	})
 
-	t.Run("WithContext", func(t *testing.T) {
-		req := NewRequest(config, "METHOD", "/")
-		req.WithContext(nil)
-		req.chain.assertFailed(t)
-	})
-
 	t.Run("WithMaxRetries", func(t *testing.T) {
 		req := NewRequest(config, "METHOD", "/")
 		req.WithMaxRetries(-1)
@@ -2201,7 +2195,7 @@ func TestValidationFailures(t *testing.T) {
 		req.chain.assertFailed(t)
 	})
 
-	t.Run("setupRedirect - http client is nil and redirect policy is not defaultRedirectPolicy", func(t *testing.T) {
+	t.Run("setupRedirect - redirect policy", func(t *testing.T) {
 		req := NewRequest(config, "METHOD", "/")
 		req.config.Client = nil
 		req.redirectPolicy = FollowAllRedirects
@@ -2209,7 +2203,7 @@ func TestValidationFailures(t *testing.T) {
 		req.chain.assertFailed(t)
 	})
 
-	t.Run("setupRedirect - http client is nil and maxRedirects is not -1", func(t *testing.T) {
+	t.Run("setupRedirect - maxRedirects is not -1", func(t *testing.T) {
 		req := NewRequest(config, "METHOD", "/")
 		req.config.Client = nil
 		req.redirectPolicy = defaultRedirectPolicy

--- a/request_test.go
+++ b/request_test.go
@@ -2239,17 +2239,6 @@ func TestValidatePanics(t *testing.T) {
 
 	reporter := newMockReporter(t)
 
-	t.Run("setBody", func(t *testing.T) {
-		config := Config{
-			RequestFactory: factory,
-			Client:         client,
-			Reporter:       reporter,
-		}
-
-		req := NewRequest(config, "METHOD", "/")
-		assert.Panics(t, func() { req.setBody("some-setter", nil, 1, false) })
-	})
-
 	t.Run("newRequest - requestFactory is nil", func(t *testing.T) {
 		config := Config{
 			RequestFactory: nil,

--- a/request_test.go
+++ b/request_test.go
@@ -2199,7 +2199,7 @@ func TestValidationFailures(t *testing.T) {
 		req := NewRequest(config, "METHOD", "/")
 		req.config.Client = nil
 		req.redirectPolicy = FollowAllRedirects
-		req.setupRedirects()
+		req.Expect() // calls setupRedirect indirectly
 		req.chain.assertFailed(t)
 	})
 
@@ -2208,44 +2208,8 @@ func TestValidationFailures(t *testing.T) {
 		req.config.Client = nil
 		req.redirectPolicy = defaultRedirectPolicy
 		req.maxRedirects = 0
-		req.setupRedirects()
+		req.Expect() // calls setupRedirect indirectly
 		req.chain.assertFailed(t)
-	})
-
-	t.Run("encodeWebsocketRequest", func(t *testing.T) {
-		req := NewRequest(config, "METHOD", "/")
-		req.bodySetter = "some value"
-		req.encodeWebsocketRequest()
-		req.chain.assertFailed(t)
-	})
-}
-
-func TestEncodeWebsocketRequest(t *testing.T) {
-	factory := DefaultRequestFactory{}
-
-	client := &mockClient{}
-
-	reporter := newMockReporter(t)
-
-	config := Config{
-		RequestFactory: factory,
-		Client:         client,
-		Reporter:       reporter,
-	}
-
-	t.Run("Http request as https", func(t *testing.T) {
-		req := NewRequest(config, "METHOD", "/")
-		req.httpReq.URL.Scheme = "https"
-		actual := req.encodeWebsocketRequest()
-		assert.Equal(t, "wss", req.httpReq.URL.Scheme)
-		assert.True(t, actual)
-	})
-
-	t.Run("Req chain failure", func(t *testing.T) {
-		req := NewRequest(config, "METHOD", "/")
-		req.chain.setFailed()
-		actual := req.encodeWebsocketRequest()
-		assert.False(t, actual)
 	})
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -2128,6 +2128,80 @@ func TestRequestRedirect(t *testing.T) {
 	})
 }
 
+func TestValidationFailures(t *testing.T){
+	factory := DefaultRequestFactory{}
+
+	client := &mockClient{}
+
+	reporter := newMockReporter(t)
+
+	config := Config{
+		RequestFactory: factory,
+		Client:         client,
+		Reporter:       reporter,
+	}
+
+	t.Run("WithMatcher", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithMatcher(nil)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithContext", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithContext(nil)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithMaxRetries", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithMaxRetries(-1)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithMaxRedirects", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithMaxRedirects(-1)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithRetryDelay", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithRetryDelay(10,5)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithWebsocketDialer", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithWebsocketDialer(nil)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithPath", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithPath("test-path",nil)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithQuery", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithQuery("test-query",nil)
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithURL", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithURL("%-invalid-url")
+		req.chain.assertFailed(t)
+	})
+
+	t.Run("WithFile", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.WithFile("test-key","test-path",nil,nil)
+		req.chain.assertFailed(t)
+	})
+}
+
 // mockTransportRedirect mocks a transport that implements RoundTripper
 //
 // When tripCount < maxRedirect,

--- a/request_test.go
+++ b/request_test.go
@@ -2238,12 +2238,21 @@ func TestEncodeWebsocketRequest(t *testing.T) {
 		Client:         client,
 		Reporter:       reporter,
 	}
+	
+	t.Run("Http request as https", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.httpReq.URL.Scheme = "https"
+		actual := req.encodeWebsocketRequest()
+		assert.Equal(t, "wss", req.httpReq.URL.Scheme)
+		assert.True(t, actual)
+	})
 
-	req := NewRequest(config, "METHOD", "/")
-	req.httpReq.URL.Scheme = "https"
-	actual := req.encodeWebsocketRequest()
-	assert.Equal(t, "wss", req.httpReq.URL.Scheme)
-	assert.True(t, actual)
+	t.Run("Req chain failure", func(t *testing.T) {
+		req := NewRequest(config, "METHOD", "/")
+		req.chain.setFailed()
+		actual := req.encodeWebsocketRequest()
+		assert.False(t, actual)
+	})
 }
 
 func TestWithRetryDelay(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -2283,11 +2283,7 @@ func TestValidatePanics(t *testing.T) {
 		}
 
 		req := NewRequest(config, "METHOD", "/")
-		defer func() {
-			err := recover()
-			assert.Equal(t, "invalid length", err)
-		}()
-		req.setBody("some-setter", nil, 1, false)
+		assert.Panics(t, func() { req.setBody("some-setter", nil, 1, false) })
 	})
 
 	t.Run("newRequest - requestFactory is nil", func(t *testing.T) {
@@ -2297,11 +2293,7 @@ func TestValidatePanics(t *testing.T) {
 			Reporter:       reporter,
 		}
 
-		defer func() {
-			err := recover()
-			assert.Equal(t, "Config.RequestFactory is nil", err)
-		}()
-		newRequest(nil, config, "", "")
+		assert.Panics(t, func() { newRequest(nil, config, "", "") })
 	})
 
 	t.Run("newRequest - client is nil", func(t *testing.T) {
@@ -2311,11 +2303,7 @@ func TestValidatePanics(t *testing.T) {
 			Reporter:       reporter,
 		}
 
-		defer func() {
-			err := recover()
-			assert.Equal(t, "Config.Client is nil", err)
-		}()
-		newRequest(nil, config, "", "")
+		assert.Panics(t, func() { newRequest(nil, config, "", "") })
 	})
 
 	t.Run("newRequest - AssertionHandler is nil", func(t *testing.T) {
@@ -2326,11 +2314,7 @@ func TestValidatePanics(t *testing.T) {
 		}
 		config.AssertionHandler = nil
 
-		defer func() {
-			err := recover()
-			assert.Equal(t, "Config.AssertionHandler is nil", err)
-		}()
-		newRequest(nil, config, "", "")
+		assert.Panics(t, func() { newRequest(nil, config, "", "") })
 	})
 }
 


### PR DESCRIPTION
Add test cases for panics and validation failures in request.go file. This increases the test coverage as well. This is for [Issue 164](https://github.com/gavv/httpexpect/issues/164)