### PR TITLE
Refactor formatValue

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -541,7 +541,6 @@ func isNil(value interface{}) bool {
 	return value == nil || reflect.ValueOf(value).IsNil()
 }
 
-// For number types other than float32 and float64
 func isNumber(value interface{}) bool {
 	defer func() {
 		_ = recover()

--- a/formatter.go
+++ b/formatter.go
@@ -391,14 +391,22 @@ func (f *DefaultFormatter) fillDelta(
 	data *FormatData, ctx *AssertionContext, failure *AssertionFailure,
 ) {
 	data.HaveDelta = true
-	data.Delta = formatFloat(failure.Delta.Value)
+	data.Delta = formatValue(failure.Delta.Value)
 }
 
 func formatTyped(value interface{}) string {
+	if isNumber(value) {
+		return fmt.Sprintf("%T(%v)", value, formatValue(value))
+	}
+
 	return fmt.Sprintf("%T(%#v)", value, value)
 }
 
 func formatValue(value interface{}) string {
+	if isNumber(value) {
+		return fmt.Sprintf("%v", value)
+	}
+
 	if !isNil(value) && !isHTTP(value) {
 		if s, _ := value.(fmt.Stringer); s != nil {
 			if ss := s.String(); strings.TrimSpace(ss) != "" {
@@ -426,24 +434,11 @@ func formatBareString(value interface{}) string {
 	return formatValue(value)
 }
 
-func formatFloat(value interface{}) string {
-	switch value.(type) {
-	case float32, float64:
-		return fmt.Sprintf("%f", value)
-	}
-
-	if isNumber(value) {
-		return fmt.Sprintf("%v", value)
-	}
-
-	return formatValue(value)
-}
-
 func formatRange(value interface{}) []string {
 	if rng := exctractRange(value); rng != nil {
 		if isNumber(rng.Min) && isNumber(rng.Max) {
 			return []string{
-				fmt.Sprintf("[%v; %v]", rng.Min, rng.Max),
+				fmt.Sprintf("[%v; %v]", formatValue(rng.Min), formatValue(rng.Max)),
 			}
 		} else {
 			return []string{

--- a/formatter.go
+++ b/formatter.go
@@ -277,21 +277,21 @@ func (f *DefaultFormatter) fillExpected(
 		data.HaveExpected = true
 		data.ExpectedKind = kindSchema
 		data.Expected = []string{
-			formatString(failure.Expected.Value),
+			formatBareString(failure.Expected.Value),
 		}
 
 	case AssertMatchPath, AssertNotMatchPath:
 		data.HaveExpected = true
 		data.ExpectedKind = kindPath
 		data.Expected = []string{
-			formatString(failure.Expected.Value),
+			formatBareString(failure.Expected.Value),
 		}
 
 	case AssertMatchRegexp, AssertNotMatchRegexp:
 		data.HaveExpected = true
 		data.ExpectedKind = kindRegexp
 		data.Expected = []string{
-			formatString(failure.Expected.Value),
+			formatBareString(failure.Expected.Value),
 		}
 
 	case AssertMatchFormat, AssertNotMatchFormat:
@@ -417,7 +417,7 @@ func formatValue(value interface{}) string {
 	return sq.Sdump(value)
 }
 
-func formatString(value interface{}) string {
+func formatBareString(value interface{}) string {
 	switch v := value.(type) {
 	case string:
 		return v
@@ -541,6 +541,7 @@ func isNil(value interface{}) bool {
 	return value == nil || reflect.ValueOf(value).IsNil()
 }
 
+// For number types other than float32 and float64
 func isNumber(value interface{}) bool {
 	defer func() {
 		_ = recover()

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -102,6 +102,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		wantHaveActual bool
 		wantActual     string
 	}{
+		// AssertType
 		{
 			name:           "AssertType nil",
 			assertionType:  AssertType,
@@ -133,16 +134,60 @@ func TestFormatDataFailureActual(t *testing.T) {
 		{
 			name:           "AssertType string",
 			assertionType:  AssertType,
-			assertionValue: "value string",
+			assertionValue: "test string",
 			wantHaveActual: true,
-			wantActual:     "string(\"value string\")",
+			wantActual:     "string(\"test string\")",
 		},
 		{
 			name:           "AssertType object",
 			assertionType:  AssertType,
-			assertionValue: struct{ Name string }{"testName"},
+			assertionValue: struct{ Name string }{"test name"},
 			wantHaveActual: true,
-			wantActual:     "struct { Name string }(struct { Name string }{Name:\"testName\"})",
+			wantActual:     "struct { Name string }(struct { Name string }{Name:\"test name\"})",
+		},
+
+		// AssertValid
+		{
+			name:           "AssertValid nil",
+			assertionType:  AssertValid,
+			assertionValue: nil,
+			wantHaveActual: true,
+			wantActual:     "nil",
+		},
+		{
+			name:           "AssertValid int",
+			assertionType:  AssertValid,
+			assertionValue: int(1_000_000),
+			wantHaveActual: true,
+			wantActual:     "1000000",
+		},
+		{
+			name:           "AssertValid float32",
+			assertionType:  AssertValid,
+			assertionValue: float32(1_000_000),
+			wantHaveActual: true,
+			wantActual:     "1e+06",
+		},
+		{
+			name:           "AssertValid float64",
+			assertionType:  AssertValid,
+			assertionValue: float64(1_000_000),
+			wantHaveActual: true,
+			wantActual:     "1e+06",
+		},
+		{
+			name:           "AssertValid string",
+			assertionType:  AssertValid,
+			assertionValue: "test string",
+			wantHaveActual: true,
+			wantActual:     "\"test string\"",
+		},
+		{
+			name:           "AssertValid object",
+			assertionType:  AssertValid,
+			assertionValue: struct{ Name string }{"test name"},
+			wantHaveActual: true,
+			wantActual:     "{\n  \"Name\": \"test name\"\n}",
 		},
 	}
 
@@ -222,23 +267,23 @@ func TestFormatDataFailureExpected(t *testing.T) {
 			name:          "AssertInRange string",
 			assertionType: AssertInRange,
 			assertionValue: AssertionRange{
-				Min: "string 1",
-				Max: "string 2",
+				Min: "test string 1",
+				Max: "test string 2",
 			},
 			wantHaveExpected: true,
 			wantExpectedKind: kindRange,
-			wantExpected:     []string{"string 1", "string 2"},
+			wantExpected:     []string{"test string 1", "test string 2"},
 		},
 		{
 			name:          "AssertInRange object",
 			assertionType: AssertInRange,
 			assertionValue: AssertionRange{
-				Min: struct{ Name string }{"testName1"},
-				Max: struct{ Name string }{"testName2"},
+				Min: struct{ Name string }{"test name 1"},
+				Max: struct{ Name string }{"test name 2"},
 			},
 			wantHaveExpected: true,
 			wantExpectedKind: kindRange,
-			wantExpected:     []string{"{testName1}", "{testName2}"},
+			wantExpected:     []string{"{test name 1}", "{test name 2}"},
 		},
 
 		// AssertMatchPath
@@ -277,18 +322,18 @@ func TestFormatDataFailureExpected(t *testing.T) {
 		{
 			name:             "AssertMatchPath string",
 			assertionType:    AssertMatchPath,
-			assertionValue:   "match path string",
+			assertionValue:   "test string",
 			wantHaveExpected: true,
 			wantExpectedKind: kindPath,
-			wantExpected:     []string{"match path string"},
+			wantExpected:     []string{"test string"},
 		},
 		{
 			name:             "AssertMatchPath object",
 			assertionType:    AssertMatchPath,
-			assertionValue:   struct{ Name string }{"testName"},
+			assertionValue:   struct{ Name string }{"test name"},
 			wantHaveExpected: true,
 			wantExpectedKind: kindPath,
-			wantExpected:     []string{"{\n  \"Name\": \"testName\"\n}"},
+			wantExpected:     []string{"{\n  \"Name\": \"test name\"\n}"},
 		},
 
 		// AssertMatchFormat
@@ -340,24 +385,24 @@ func TestFormatDataFailureExpected(t *testing.T) {
 			name:          "AssertMatchFormat string",
 			assertionType: AssertMatchFormat,
 			assertionValue: AssertionList{
-				"string 1",
-				"string 2",
+				"test string 1",
+				"test string 2",
 			},
 			wantHaveExpected: true,
 			wantExpectedKind: kindFormatList,
-			wantExpected:     []string{"\"string 1\"", "\"string 2\""},
+			wantExpected:     []string{"\"test string 1\"", "\"test string 2\""},
 		},
 		{
 			name:          "AssertMatchFormat object",
 			assertionType: AssertMatchFormat,
 			assertionValue: AssertionList{
-				struct{ Name string }{"testName1"},
-				struct{ Name string }{"testName2"},
+				struct{ Name string }{"test name 1"},
+				struct{ Name string }{"test name 2"},
 			},
 			wantHaveExpected: true,
 			wantExpectedKind: kindFormatList,
 			wantExpected: []string{
-				"{\n  \"Name\": \"testName1\"\n}", "{\n  \"Name\": \"testName2\"\n}",
+				"{\n  \"Name\": \"test name 1\"\n}", "{\n  \"Name\": \"test name 2\"\n}",
 			},
 		},
 	}
@@ -414,15 +459,15 @@ func TestFormatDataFailureReference(t *testing.T) {
 		},
 		{
 			name:              "string",
-			assertionValue:    "reference string",
+			assertionValue:    "test string",
 			wantHaveReference: true,
-			wantReference:     "\"reference string\"",
+			wantReference:     "\"test string\"",
 		},
 		{
 			name:              "object",
-			assertionValue:    struct{ Name string }{"testName"},
+			assertionValue:    struct{ Name string }{"test name"},
 			wantHaveReference: true,
-			wantReference:     "{\n  \"Name\": \"testName\"\n}",
+			wantReference:     "{\n  \"Name\": \"test name\"\n}",
 		},
 	}
 
@@ -476,15 +521,15 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		},
 		{
 			name:           "string",
-			assertionValue: "delta string",
+			assertionValue: "test string",
 			wantHaveDelta:  true,
-			wantDelta:      "\"delta string\"",
+			wantDelta:      "\"test string\"",
 		},
 		{
 			name:           "object",
-			assertionValue: struct{ Name string }{"testName"},
+			assertionValue: struct{ Name string }{"test name"},
 			wantHaveDelta:  true,
-			wantDelta:      "{\n  \"Name\": \"testName\"\n}",
+			wantDelta:      "{\n  \"Name\": \"test name\"\n}",
 		},
 	}
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -52,7 +52,7 @@ func TestFormatValues(t *testing.T) {
 		checkAll(t, formatValue)
 	})
 
-	t.Run("formatString", func(t *testing.T) {
+	t.Run("formatBareString", func(t *testing.T) {
 		checkAll(t, formatBareString)
 	})
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -95,13 +95,14 @@ func TestFormatDiff(t *testing.T) {
 }
 
 func TestFormatFailure_Actual(t *testing.T) {
+	df := &DefaultFormatter{}
+	ctx := &AssertionContext{}
+
 	t.Run("assert type integer", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
-				Value: 1_000_000,
+				Value: int(1_000_000),
 			},
 		}
 		tmpl := df.FormatFailure(ctx, fl)
@@ -109,8 +110,6 @@ func TestFormatFailure_Actual(t *testing.T) {
 	})
 
 	t.Run("assert type float32", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -122,8 +121,6 @@ func TestFormatFailure_Actual(t *testing.T) {
 	})
 
 	t.Run("assert type float64", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -135,8 +132,6 @@ func TestFormatFailure_Actual(t *testing.T) {
 	})
 
 	t.Run("assert type string", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -149,15 +144,16 @@ func TestFormatFailure_Actual(t *testing.T) {
 }
 
 func TestFormatFailure_Expected(t *testing.T) {
+	df := &DefaultFormatter{}
+	ctx := &AssertionContext{}
+
 	t.Run("assert in range integer", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertInRange,
 			Expected: &AssertionValue{
 				AssertionRange{
-					Min: 1_000_000,
-					Max: 2_000_000,
+					Min: int(1_000_000),
+					Max: int(2_000_000),
 				},
 			},
 		}
@@ -166,8 +162,6 @@ func TestFormatFailure_Expected(t *testing.T) {
 	})
 
 	t.Run("assert in range float32", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertInRange,
 			Expected: &AssertionValue{
@@ -182,8 +176,6 @@ func TestFormatFailure_Expected(t *testing.T) {
 	})
 
 	t.Run("assert in range float64", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertInRange,
 			Expected: &AssertionValue{
@@ -198,8 +190,6 @@ func TestFormatFailure_Expected(t *testing.T) {
 	})
 
 	t.Run("assert in range string", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Type: AssertInRange,
 			Expected: &AssertionValue{
@@ -216,9 +206,10 @@ func TestFormatFailure_Expected(t *testing.T) {
 }
 
 func TestFormatFailure_Delta(t *testing.T) {
+	df := &DefaultFormatter{}
+	ctx := &AssertionContext{}
+
 	t.Run("integer", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Delta: &AssertionValue{
 				Value: int(1_000_000),
@@ -229,8 +220,6 @@ func TestFormatFailure_Delta(t *testing.T) {
 	})
 
 	t.Run("float32", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Delta: &AssertionValue{
 				Value: float32(1_000_000),
@@ -241,8 +230,6 @@ func TestFormatFailure_Delta(t *testing.T) {
 	})
 
 	t.Run("float64", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Delta: &AssertionValue{
 				Value: float64(1_000_000),
@@ -253,8 +240,6 @@ func TestFormatFailure_Delta(t *testing.T) {
 	})
 
 	t.Run("string", func(t *testing.T) {
-		df := &DefaultFormatter{}
-		ctx := &AssertionContext{}
 		fl := &AssertionFailure{
 			Delta: &AssertionValue{
 				Value: "delta string",

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -95,86 +95,87 @@ func TestFormatDiff(t *testing.T) {
 }
 
 func TestFormatDataFailureActual(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      AssertionType
+		val      interface{}
+		assertFn func(t *testing.T, fd *FormatData)
+	}{
+		{
+			name: "AssertType nil",
+			typ:  AssertType,
+			val:  nil,
+			assertFn: func(t *testing.T, fd *FormatData) {
+				assert.True(t, fd.HaveActual)
+				assert.Equal(t, "<nil>(<nil>)", fd.Actual)
+			},
+		},
+		{
+			name: "AssertType int",
+			typ:  AssertType,
+			val:  int(1_000_000),
+			assertFn: func(t *testing.T, fd *FormatData) {
+				assert.True(t, fd.HaveActual)
+				assert.Equal(t, "int(1000000)", fd.Actual)
+			},
+		},
+		{
+			name: "AssertType float32",
+			typ:  AssertType,
+			val:  float32(1_000_000),
+			assertFn: func(t *testing.T, fd *FormatData) {
+				assert.True(t, fd.HaveActual)
+				assert.Equal(t, "float32(1e+06)", fd.Actual)
+			},
+		},
+		{
+			name: "AssertType float64",
+			typ:  AssertType,
+			val:  float64(1_000_000),
+			assertFn: func(t *testing.T, fd *FormatData) {
+				assert.True(t, fd.HaveActual)
+				assert.Equal(t, "float64(1e+06)", fd.Actual)
+			},
+		},
+		{
+			name: "AssertType string",
+			typ:  AssertType,
+			val:  "value string",
+			assertFn: func(t *testing.T, fd *FormatData) {
+				assert.True(t, fd.HaveActual)
+				assert.Equal(t, "string(\"value string\")", fd.Actual)
+			},
+		},
+		{
+			name: "AssertType object",
+			typ:  AssertType,
+			val:  struct{ Name string }{"testName"},
+			assertFn: func(t *testing.T, fd *FormatData) {
+				assert.True(t, fd.HaveActual)
+				assert.Equal(
+					t,
+					"struct { Name string }(struct { Name string }{Name:\"testName\"})",
+					fd.Actual,
+				)
+			},
+		},
+	}
+
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
-	t.Run("AssertType nil", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertType,
-			Actual: &AssertionValue{
-				Value: nil,
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveActual)
-		assert.Equal(t, "<nil>(<nil>)", fd.Actual)
-	})
-
-	t.Run("AssertType int", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertType,
-			Actual: &AssertionValue{
-				Value: int(1_000_000),
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveActual)
-		assert.Equal(t, "int(1000000)", fd.Actual)
-
-	})
-
-	t.Run("AssertType float32", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertType,
-			Actual: &AssertionValue{
-				Value: float32(1_000_000),
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveActual)
-		assert.Equal(t, "float32(1e+06)", fd.Actual)
-	})
-
-	t.Run("AssertType float64", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertType,
-			Actual: &AssertionValue{
-				Value: float64(1_000_000),
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveActual)
-		assert.Equal(t, "float64(1e+06)", fd.Actual)
-	})
-
-	t.Run("AssertType string", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertType,
-			Actual: &AssertionValue{
-				Value: "value string",
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveActual)
-		assert.Equal(t, "string(\"value string\")", fd.Actual)
-	})
-
-	t.Run("AssertType object", func(t *testing.T) {
-		obj := struct{ Name string }{"testName"}
-		fl := &AssertionFailure{
-			Type: AssertType,
-			Actual: &AssertionValue{
-				Value: obj,
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveActual)
-		assert.Equal(
-			t,
-			"struct { Name string }(struct { Name string }{Name:\"testName\"})",
-			fd.Actual,
-		)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: tc.typ,
+				Actual: &AssertionValue{
+					Value: tc.val,
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			tc.assertFn(t, fd)
+		})
+	}
 }
 
 func TestFormatDataFailureExpected(t *testing.T) {

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -98,7 +98,19 @@ func TestFormatDataFailureActual(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
-	t.Run("assert type integer", func(t *testing.T) {
+	t.Run("AssertType nil", func(t *testing.T) {
+		fl := &AssertionFailure{
+			Type: AssertType,
+			Actual: &AssertionValue{
+				Value: nil,
+			},
+		}
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveActual)
+		assert.Equal(t, "<nil>(<nil>)", fd.Actual)
+	})
+
+	t.Run("AssertType int", func(t *testing.T) {
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -111,7 +123,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 
 	})
 
-	t.Run("assert type float32", func(t *testing.T) {
+	t.Run("AssertType float32", func(t *testing.T) {
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -123,7 +135,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		assert.Equal(t, "float32(1e+06)", fd.Actual)
 	})
 
-	t.Run("assert type float64", func(t *testing.T) {
+	t.Run("AssertType float64", func(t *testing.T) {
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -135,7 +147,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		assert.Equal(t, "float64(1e+06)", fd.Actual)
 	})
 
-	t.Run("assert type string", func(t *testing.T) {
+	t.Run("AssertType string", func(t *testing.T) {
 		fl := &AssertionFailure{
 			Type: AssertType,
 			Actual: &AssertionValue{
@@ -147,7 +159,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		assert.Equal(t, "string(\"value string\")", fd.Actual)
 	})
 
-	t.Run("assert type object", func(t *testing.T) {
+	t.Run("AssertType object", func(t *testing.T) {
 		obj := struct{ Name string }{"testName"}
 		fl := &AssertionFailure{
 			Type: AssertType,
@@ -169,238 +181,291 @@ func TestFormatDataFailureExpected(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
-	t.Run("assert in range integer", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertInRange,
-			Expected: &AssertionValue{
-				Value: AssertionRange{
-					Min: int(1_000_000),
-					Max: int(2_000_000),
+	t.Run("AssertInRange", func(t *testing.T) {
+		t.Run("nil", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertInRange,
+				Expected: &AssertionValue{
+					Value: AssertionRange{
+						Min: nil,
+						Max: nil,
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindRange, fd.ExpectedKind)
-		assert.Equal(t, []string{"[1000000; 2000000]"}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindRange, fd.ExpectedKind)
+			assert.Equal(t, []string{"<nil>", "<nil>"}, fd.Expected)
+		})
 
-	t.Run("assert in range float32", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertInRange,
-			Expected: &AssertionValue{
-				Value: AssertionRange{
-					Min: float32(1_000_000),
-					Max: float32(2_000_000),
+		t.Run("int", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertInRange,
+				Expected: &AssertionValue{
+					Value: AssertionRange{
+						Min: int(1_000_000),
+						Max: int(2_000_000),
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindRange, fd.ExpectedKind)
-		assert.Equal(t, []string{"[1e+06; 2e+06]"}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindRange, fd.ExpectedKind)
+			assert.Equal(t, []string{"[1000000; 2000000]"}, fd.Expected)
+		})
 
-	t.Run("assert in range float64", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertInRange,
-			Expected: &AssertionValue{
-				Value: AssertionRange{
-					Min: float64(1_000_000),
-					Max: float64(2_000_000),
+		t.Run("float32", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertInRange,
+				Expected: &AssertionValue{
+					Value: AssertionRange{
+						Min: float32(1_000_000),
+						Max: float32(2_000_000),
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindRange, fd.ExpectedKind)
-		assert.Equal(t, []string{"[1e+06; 2e+06]"}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindRange, fd.ExpectedKind)
+			assert.Equal(t, []string{"[1e+06; 2e+06]"}, fd.Expected)
+		})
 
-	t.Run("assert in range string", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertInRange,
-			Expected: &AssertionValue{
-				Value: AssertionRange{
-					Min: "string 1",
-					Max: "string 2",
+		t.Run("float64", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertInRange,
+				Expected: &AssertionValue{
+					Value: AssertionRange{
+						Min: float64(1_000_000),
+						Max: float64(2_000_000),
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindRange, fd.ExpectedKind)
-		assert.Equal(t, []string{"string 1", "string 2"}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindRange, fd.ExpectedKind)
+			assert.Equal(t, []string{"[1e+06; 2e+06]"}, fd.Expected)
+		})
 
-	t.Run("assert in range object", func(t *testing.T) {
-		obj1 := struct{ Name string }{"testName1"}
-		obj2 := struct{ Name string }{"testName2"}
-		fl := &AssertionFailure{
-			Type: AssertInRange,
-			Expected: &AssertionValue{
-				Value: AssertionRange{
-					Min: obj1,
-					Max: obj2,
+		t.Run("string", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertInRange,
+				Expected: &AssertionValue{
+					Value: AssertionRange{
+						Min: "string 1",
+						Max: "string 2",
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindRange, fd.ExpectedKind)
-		assert.Equal(t, []string{"{testName1}", "{testName2}"}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindRange, fd.ExpectedKind)
+			assert.Equal(t, []string{"string 1", "string 2"}, fd.Expected)
+		})
 
-	t.Run("assert match path integer", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchPath,
-			Expected: &AssertionValue{
-				Value: int(1_000_000),
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindPath, fd.ExpectedKind)
-		assert.Equal(t, []string{"1000000"}, fd.Expected)
-	})
-
-	t.Run("assert match path float32", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchPath,
-			Expected: &AssertionValue{
-				Value: float32(1_000_000),
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindPath, fd.ExpectedKind)
-		assert.Equal(t, []string{"1000000"}, fd.Expected)
-	})
-
-	t.Run("assert match path float64", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchPath,
-			Expected: &AssertionValue{
-				Value: float64(1_000_000),
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindPath, fd.ExpectedKind)
-		assert.Equal(t, []string{"1000000"}, fd.Expected)
-	})
-
-	t.Run("assert match path string", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchPath,
-			Expected: &AssertionValue{
-				Value: "match path string",
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindPath, fd.ExpectedKind)
-		assert.Equal(t, []string{"match path string"}, fd.Expected)
-	})
-
-	t.Run("assert match path object", func(t *testing.T) {
-		obj := struct{ Name string }{"testName"}
-		fl := &AssertionFailure{
-			Type: AssertMatchPath,
-			Expected: &AssertionValue{
-				Value: obj,
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindPath, fd.ExpectedKind)
-		assert.Equal(t, []string{"{\n  \"Name\": \"testName\"\n}"}, fd.Expected)
-	})
-
-	t.Run("assert match format list integer", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchFormat,
-			Expected: &AssertionValue{
-				Value: AssertionList{
-					int(1_000_000),
-					int(2_000_000),
+		t.Run("object", func(t *testing.T) {
+			obj1 := struct{ Name string }{"testName1"}
+			obj2 := struct{ Name string }{"testName2"}
+			fl := &AssertionFailure{
+				Type: AssertInRange,
+				Expected: &AssertionValue{
+					Value: AssertionRange{
+						Min: obj1,
+						Max: obj2,
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindFormatList, fd.ExpectedKind)
-		assert.Equal(t, []string{"1000000", "2000000"}, fd.Expected)
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindRange, fd.ExpectedKind)
+			assert.Equal(t, []string{"{testName1}", "{testName2}"}, fd.Expected)
+		})
+
 	})
 
-	t.Run("assert match format list float32", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchFormat,
-			Expected: &AssertionValue{
-				Value: AssertionList{
-					float32(1_000_000),
-					float32(2_000_000),
+	t.Run("AssertMatchPath", func(t *testing.T) {
+		t.Run("nil", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchPath,
+				Expected: &AssertionValue{
+					Value: nil,
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindFormatList, fd.ExpectedKind)
-		assert.Equal(t, []string{"1000000", "2000000"}, fd.Expected)
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindPath, fd.ExpectedKind)
+			assert.Equal(t, []string{"nil"}, fd.Expected)
+		})
+
+		t.Run("int", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchPath,
+				Expected: &AssertionValue{
+					Value: int(1_000_000),
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindPath, fd.ExpectedKind)
+			assert.Equal(t, []string{"1000000"}, fd.Expected)
+		})
+
+		t.Run("float32", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchPath,
+				Expected: &AssertionValue{
+					Value: float32(1_000_000),
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindPath, fd.ExpectedKind)
+			assert.Equal(t, []string{"1e+06"}, fd.Expected)
+		})
+
+		t.Run("float64", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchPath,
+				Expected: &AssertionValue{
+					Value: float64(1_000_000),
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindPath, fd.ExpectedKind)
+			assert.Equal(t, []string{"1e+06"}, fd.Expected)
+		})
+
+		t.Run("string", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchPath,
+				Expected: &AssertionValue{
+					Value: "match path string",
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindPath, fd.ExpectedKind)
+			assert.Equal(t, []string{"match path string"}, fd.Expected)
+		})
+
+		t.Run("object", func(t *testing.T) {
+			obj := struct{ Name string }{"testName"}
+			fl := &AssertionFailure{
+				Type: AssertMatchPath,
+				Expected: &AssertionValue{
+					Value: obj,
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindPath, fd.ExpectedKind)
+			assert.Equal(t, []string{"{\n  \"Name\": \"testName\"\n}"}, fd.Expected)
+		})
+
 	})
 
-	t.Run("assert match format list float64", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchFormat,
-			Expected: &AssertionValue{
-				Value: AssertionList{
-					float64(1_000_000),
-					float64(2_000_000),
+	t.Run("AssertMatchFormat", func(t *testing.T) {
+		t.Run("int", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchFormat,
+				Expected: &AssertionValue{
+					Value: AssertionList{
+						nil,
+						nil,
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindFormatList, fd.ExpectedKind)
-		assert.Equal(t, []string{"1000000", "2000000"}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindFormatList, fd.ExpectedKind)
+			assert.Equal(t, []string{"nil", "nil"}, fd.Expected)
+		})
 
-	t.Run("assert match format list string", func(t *testing.T) {
-		fl := &AssertionFailure{
-			Type: AssertMatchFormat,
-			Expected: &AssertionValue{
-				Value: AssertionList{
-					"string 1",
-					"string 2",
+		t.Run("int", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchFormat,
+				Expected: &AssertionValue{
+					Value: AssertionList{
+						int(1_000_000),
+						int(2_000_000),
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindFormatList, fd.ExpectedKind)
-		assert.Equal(t, []string{"\"string 1\"", "\"string 2\""}, fd.Expected)
-	})
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindFormatList, fd.ExpectedKind)
+			assert.Equal(t, []string{"1000000", "2000000"}, fd.Expected)
+		})
 
-	t.Run("assert match format list object", func(t *testing.T) {
-		obj1 := struct{ Name string }{"testName1"}
-		obj2 := struct{ Name string }{"testName2"}
-		fl := &AssertionFailure{
-			Type: AssertMatchFormat,
-			Expected: &AssertionValue{
-				Value: AssertionList{
-					obj1,
-					obj2,
+		t.Run("float32", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchFormat,
+				Expected: &AssertionValue{
+					Value: AssertionList{
+						float32(1_000_000),
+						float32(2_000_000),
+					},
 				},
-			},
-		}
-		fd := df.buildFormatData(ctx, fl)
-		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, kindFormatList, fd.ExpectedKind)
-		assert.Equal(
-			t,
-			[]string{"{\n  \"Name\": \"testName1\"\n}", "{\n  \"Name\": \"testName2\"\n}"},
-			fd.Expected,
-		)
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindFormatList, fd.ExpectedKind)
+			assert.Equal(t, []string{"1e+06", "2e+06"}, fd.Expected)
+		})
+
+		t.Run("float64", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchFormat,
+				Expected: &AssertionValue{
+					Value: AssertionList{
+						float64(1_000_000),
+						float64(2_000_000),
+					},
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindFormatList, fd.ExpectedKind)
+			assert.Equal(t, []string{"1e+06", "2e+06"}, fd.Expected)
+		})
+
+		t.Run("string", func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: AssertMatchFormat,
+				Expected: &AssertionValue{
+					Value: AssertionList{
+						"string 1",
+						"string 2",
+					},
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindFormatList, fd.ExpectedKind)
+			assert.Equal(t, []string{"\"string 1\"", "\"string 2\""}, fd.Expected)
+		})
+
+		t.Run("object", func(t *testing.T) {
+			obj1 := struct{ Name string }{"testName1"}
+			obj2 := struct{ Name string }{"testName2"}
+			fl := &AssertionFailure{
+				Type: AssertMatchFormat,
+				Expected: &AssertionValue{
+					Value: AssertionList{
+						obj1,
+						obj2,
+					},
+				},
+			}
+			fd := df.buildFormatData(ctx, fl)
+			assert.True(t, fd.HaveExpected)
+			assert.Equal(t, kindFormatList, fd.ExpectedKind)
+			assert.Equal(
+				t,
+				[]string{"{\n  \"Name\": \"testName1\"\n}", "{\n  \"Name\": \"testName2\"\n}"},
+				fd.Expected,
+			)
+		})
 	})
 }
 
@@ -408,7 +473,18 @@ func TestFormatDataFailureReference(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
-	t.Run("integer", func(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		fl := &AssertionFailure{
+			Reference: &AssertionValue{
+				Value: nil,
+			},
+		}
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveReference)
+		assert.Equal(t, "nil", fd.Reference)
+	})
+
+	t.Run("int", func(t *testing.T) {
 		fl := &AssertionFailure{
 			Reference: &AssertionValue{
 				Value: int(1_000_000),
@@ -427,7 +503,7 @@ func TestFormatDataFailureReference(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveReference)
-		assert.Equal(t, "1000000", fd.Reference)
+		assert.Equal(t, "1e+06", fd.Reference)
 
 	})
 
@@ -439,7 +515,7 @@ func TestFormatDataFailureReference(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveReference)
-		assert.Equal(t, "1000000", fd.Reference)
+		assert.Equal(t, "1e+06", fd.Reference)
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -470,7 +546,18 @@ func TestFormatDataFailureDelta(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
-	t.Run("integer", func(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		fl := &AssertionFailure{
+			Delta: &AssertionValue{
+				Value: nil,
+			},
+		}
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveDelta)
+		assert.Equal(t, "nil", fd.Delta)
+	})
+
+	t.Run("int", func(t *testing.T) {
 		fl := &AssertionFailure{
 			Delta: &AssertionValue{
 				Value: int(1_000_000),
@@ -489,7 +576,7 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveDelta)
-		assert.Equal(t, "1000000.000000", fd.Delta)
+		assert.Equal(t, "1e+06", fd.Delta)
 
 	})
 
@@ -501,7 +588,7 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveDelta)
-		assert.Equal(t, "1000000.000000", fd.Delta)
+		assert.Equal(t, "1e+06", fd.Delta)
 	})
 
 	t.Run("string", func(t *testing.T) {

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -93,3 +93,174 @@ func TestFormatDiff(t *testing.T) {
 	checkOK(map[string]interface{}{"a": 1}, map[string]interface{}{})
 	checkOK([]interface{}{"a"}, []interface{}{})
 }
+
+func TestFormatFailure_Actual(t *testing.T) {
+	t.Run("assert type integer", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertType,
+			Actual: &AssertionValue{
+				Value: 1_000_000,
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "int(1000000)")
+	})
+
+	t.Run("assert type float32", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertType,
+			Actual: &AssertionValue{
+				Value: float32(1_000_000),
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "float32(1e+06)")
+	})
+
+	t.Run("assert type float64", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertType,
+			Actual: &AssertionValue{
+				Value: float64(1_000_000),
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "float64(1e+06)")
+	})
+
+	t.Run("assert type string", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertType,
+			Actual: &AssertionValue{
+				Value: "value string",
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, `string("value string")`)
+	})
+}
+
+func TestFormatFailure_Expected(t *testing.T) {
+	t.Run("assert in range integer", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertInRange,
+			Expected: &AssertionValue{
+				AssertionRange{
+					Min: 1_000_000,
+					Max: 2_000_000,
+				},
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "[1000000; 2000000]")
+	})
+
+	t.Run("assert in range float32", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertInRange,
+			Expected: &AssertionValue{
+				AssertionRange{
+					Min: float32(1_000_000),
+					Max: float32(2_000_000),
+				},
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "[1e+06; 2e+06]")
+	})
+
+	t.Run("assert in range float64", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertInRange,
+			Expected: &AssertionValue{
+				AssertionRange{
+					Min: float64(1_000_000),
+					Max: float64(2_000_000),
+				},
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "[1e+06; 2e+06]")
+	})
+
+	t.Run("assert in range string", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Type: AssertInRange,
+			Expected: &AssertionValue{
+				AssertionRange{
+					Min: "min string",
+					Max: "max string",
+				},
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "min string")
+		assert.Contains(t, tmpl, "max string")
+	})
+}
+
+func TestFormatFailure_Delta(t *testing.T) {
+	t.Run("integer", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Delta: &AssertionValue{
+				Value: int(1_000_000),
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "1000000")
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Delta: &AssertionValue{
+				Value: float32(1_000_000),
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "1000000.000000")
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Delta: &AssertionValue{
+				Value: float64(1_000_000),
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "1000000.000000")
+	})
+
+	t.Run("string", func(t *testing.T) {
+		df := &DefaultFormatter{}
+		ctx := &AssertionContext{}
+		fl := &AssertionFailure{
+			Delta: &AssertionValue{
+				Value: "delta string",
+			},
+		}
+		tmpl := df.FormatFailure(ctx, fl)
+		assert.Contains(t, tmpl, "delta string")
+	})
+}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -107,7 +107,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveActual)
-		assert.Equal(t, fd.Actual, "int(1000000)")
+		assert.Equal(t, "int(1000000)", fd.Actual)
 
 	})
 
@@ -120,7 +120,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveActual)
-		assert.Equal(t, fd.Actual, "float32(1e+06)")
+		assert.Equal(t, "float32(1e+06)", fd.Actual)
 	})
 
 	t.Run("assert type float64", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveActual)
-		assert.Equal(t, fd.Actual, "float64(1e+06)")
+		assert.Equal(t, "float64(1e+06)", fd.Actual)
 	})
 
 	t.Run("assert type string", func(t *testing.T) {
@@ -144,7 +144,7 @@ func TestFormatDataFailureActual(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveActual)
-		assert.Equal(t, fd.Actual, `string("value string")`)
+		assert.Equal(t, `string("value string")`, fd.Actual)
 	})
 }
 
@@ -164,8 +164,8 @@ func TestFormatDataFailureExpected(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, fd.ExpectedKind, kindRange)
-		assert.Equal(t, fd.Expected, []string{"[1000000; 2000000]"})
+		assert.Equal(t, kindRange, fd.ExpectedKind)
+		assert.Equal(t, []string{"[1000000; 2000000]"}, fd.Expected)
 	})
 
 	t.Run("assert in range float32", func(t *testing.T) {
@@ -180,8 +180,8 @@ func TestFormatDataFailureExpected(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, fd.ExpectedKind, kindRange)
-		assert.Equal(t, fd.Expected, []string{"[1e+06; 2e+06]"})
+		assert.Equal(t, kindRange, fd.ExpectedKind)
+		assert.Equal(t, []string{"[1e+06; 2e+06]"}, fd.Expected)
 	})
 
 	t.Run("assert in range float64", func(t *testing.T) {
@@ -196,8 +196,8 @@ func TestFormatDataFailureExpected(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, fd.ExpectedKind, kindRange)
-		assert.Equal(t, fd.Expected, []string{"[1e+06; 2e+06]"})
+		assert.Equal(t, kindRange, fd.ExpectedKind)
+		assert.Equal(t, []string{"[1e+06; 2e+06]"}, fd.Expected)
 	})
 
 	t.Run("assert in range string", func(t *testing.T) {
@@ -212,8 +212,8 @@ func TestFormatDataFailureExpected(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveExpected)
-		assert.Equal(t, fd.ExpectedKind, kindRange)
-		assert.Equal(t, fd.Expected, []string{"min string", "max string"})
+		assert.Equal(t, kindRange, fd.ExpectedKind)
+		assert.Equal(t, []string{"min string", "max string"}, fd.Expected)
 	})
 }
 
@@ -229,7 +229,7 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveDelta)
-		assert.Equal(t, fd.Delta, "1000000")
+		assert.Equal(t, "1000000", fd.Delta)
 	})
 
 	t.Run("float32", func(t *testing.T) {
@@ -240,7 +240,7 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveDelta)
-		assert.Equal(t, fd.Delta, "1000000.000000")
+		assert.Equal(t, "1000000.000000", fd.Delta)
 
 	})
 
@@ -252,7 +252,7 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveDelta)
-		assert.Equal(t, fd.Delta, "1000000.000000")
+		assert.Equal(t, "1000000.000000", fd.Delta)
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -263,6 +263,6 @@ func TestFormatDataFailureDelta(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveDelta)
-		assert.Equal(t, fd.Delta, `"delta string"`)
+		assert.Equal(t, `"delta string"`, fd.Delta)
 	})
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -157,7 +157,11 @@ func TestFormatDataFailureActual(t *testing.T) {
 		}
 		fd := df.buildFormatData(ctx, fl)
 		assert.True(t, fd.HaveActual)
-		assert.Equal(t, "struct { Name string }(struct { Name string }{Name:\"testName\"})", fd.Actual)
+		assert.Equal(
+			t,
+			"struct { Name string }(struct { Name string }{Name:\"testName\"})",
+			fd.Actual,
+		)
 	})
 }
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -94,7 +94,7 @@ func TestFormatDiff(t *testing.T) {
 	checkOK([]interface{}{"a"}, []interface{}{})
 }
 
-func TestFormatFailure_Actual(t *testing.T) {
+func TestFormatDataFailureActual(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
@@ -105,8 +105,10 @@ func TestFormatFailure_Actual(t *testing.T) {
 				Value: int(1_000_000),
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "int(1000000)")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveActual)
+		assert.Equal(t, fd.Actual, "int(1000000)")
+
 	})
 
 	t.Run("assert type float32", func(t *testing.T) {
@@ -116,8 +118,9 @@ func TestFormatFailure_Actual(t *testing.T) {
 				Value: float32(1_000_000),
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "float32(1e+06)")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveActual)
+		assert.Equal(t, fd.Actual, "float32(1e+06)")
 	})
 
 	t.Run("assert type float64", func(t *testing.T) {
@@ -127,8 +130,9 @@ func TestFormatFailure_Actual(t *testing.T) {
 				Value: float64(1_000_000),
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "float64(1e+06)")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveActual)
+		assert.Equal(t, fd.Actual, "float64(1e+06)")
 	})
 
 	t.Run("assert type string", func(t *testing.T) {
@@ -138,12 +142,13 @@ func TestFormatFailure_Actual(t *testing.T) {
 				Value: "value string",
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, `string("value string")`)
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveActual)
+		assert.Equal(t, fd.Actual, `string("value string")`)
 	})
 }
 
-func TestFormatFailure_Expected(t *testing.T) {
+func TestFormatDataFailureExpected(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
@@ -157,8 +162,10 @@ func TestFormatFailure_Expected(t *testing.T) {
 				},
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "[1000000; 2000000]")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveExpected)
+		assert.Equal(t, fd.ExpectedKind, kindRange)
+		assert.Equal(t, fd.Expected, []string{"[1000000; 2000000]"})
 	})
 
 	t.Run("assert in range float32", func(t *testing.T) {
@@ -171,8 +178,10 @@ func TestFormatFailure_Expected(t *testing.T) {
 				},
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "[1e+06; 2e+06]")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveExpected)
+		assert.Equal(t, fd.ExpectedKind, kindRange)
+		assert.Equal(t, fd.Expected, []string{"[1e+06; 2e+06]"})
 	})
 
 	t.Run("assert in range float64", func(t *testing.T) {
@@ -185,8 +194,10 @@ func TestFormatFailure_Expected(t *testing.T) {
 				},
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "[1e+06; 2e+06]")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveExpected)
+		assert.Equal(t, fd.ExpectedKind, kindRange)
+		assert.Equal(t, fd.Expected, []string{"[1e+06; 2e+06]"})
 	})
 
 	t.Run("assert in range string", func(t *testing.T) {
@@ -199,13 +210,14 @@ func TestFormatFailure_Expected(t *testing.T) {
 				},
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "min string")
-		assert.Contains(t, tmpl, "max string")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveExpected)
+		assert.Equal(t, fd.ExpectedKind, kindRange)
+		assert.Equal(t, fd.Expected, []string{"min string", "max string"})
 	})
 }
 
-func TestFormatFailure_Delta(t *testing.T) {
+func TestFormatDataFailureDelta(t *testing.T) {
 	df := &DefaultFormatter{}
 	ctx := &AssertionContext{}
 
@@ -215,8 +227,9 @@ func TestFormatFailure_Delta(t *testing.T) {
 				Value: int(1_000_000),
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "1000000")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveDelta)
+		assert.Equal(t, fd.Delta, "1000000")
 	})
 
 	t.Run("float32", func(t *testing.T) {
@@ -225,8 +238,10 @@ func TestFormatFailure_Delta(t *testing.T) {
 				Value: float32(1_000_000),
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "1000000.000000")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveDelta)
+		assert.Equal(t, fd.Delta, "1000000.000000")
+
 	})
 
 	t.Run("float64", func(t *testing.T) {
@@ -235,8 +250,9 @@ func TestFormatFailure_Delta(t *testing.T) {
 				Value: float64(1_000_000),
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "1000000.000000")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveDelta)
+		assert.Equal(t, fd.Delta, "1000000.000000")
 	})
 
 	t.Run("string", func(t *testing.T) {
@@ -245,7 +261,8 @@ func TestFormatFailure_Delta(t *testing.T) {
 				Value: "delta string",
 			},
 		}
-		tmpl := df.FormatFailure(ctx, fl)
-		assert.Contains(t, tmpl, "delta string")
+		fd := df.buildFormatData(ctx, fl)
+		assert.True(t, fd.HaveDelta)
+		assert.Equal(t, fd.Delta, `"delta string"`)
 	})
 }


### PR DESCRIPTION
Issue: (part of) #190 

Refactoring before proceeding to introduce `DefaultFormatter.DisableScientific` as mentioned in https://github.com/gavv/httpexpect/issues/190#issuecomment-1356196337.

Refactoring (more detail https://github.com/gavv/httpexpect/issues/190#issuecomment-1356181798):

- Delete `formatFloat`. Replace with `formatValue`
- Rework `formatTyped` to use `formatValue`
- Rework `formatRange` to use `formatValue`
- Introduce _scientific_ as default float format

Tasks:

- [x] Add unit test to _catch_ potential breaking early
- [x] Refactor
- [x] Re-evaluate unit test

~PR will be draft, unless all tasks are checked~

PR is now ready