### PR TITLE
FatalReporter implementation

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -158,10 +158,11 @@ type Config struct {
 	// constructed when AssertionHandler is nil.
 	//
 	// You can use:
-	// - AssertReporter / RequireReporter (non-fatal / fatal failures using testify package)
-	// - testing.T / FatalReporter (non-fatal / fatal failures
-	//   using standard testing package)
-	// - custom implementation
+	//  - AssertReporter / RequireReporter
+	//    (non-fatal / fatal failures using testify package)
+	//  - testing.T / FatalReporter
+	//    (non-fatal / fatal failures using standard testing package)
+	//  - custom implementation
 	Reporter Reporter
 
 	// Formatter is used to format success and failure messages.
@@ -312,7 +313,7 @@ type WebsocketDialer interface {
 }
 
 // Reporter is used to report failures.
-// *testing.T, AssertReporter, FatalReporter and RequireReporter implement this interface.
+// *testing.T, AssertReporter, RequireReporter, and FatalReporter implement this interface.
 type Reporter interface {
 	// Errorf reports failure.
 	// Allowed to return normally or terminate test using t.FailNow().

--- a/expect.go
+++ b/expect.go
@@ -159,6 +159,7 @@ type Config struct {
 	//
 	// You can use AssertReporter, RequireReporter (they use testify),
 	// or *testing.T, or provide custom implementation.
+	// You can also Use FatalReporter that use testing.TB
 	Reporter Reporter
 
 	// Formatter is used to format success and failure messages.

--- a/expect.go
+++ b/expect.go
@@ -157,9 +157,11 @@ type Config struct {
 	// Config.Reporter is used by DefaultAssertionHandler, which is automatically
 	// constructed when AssertionHandler is nil.
 	//
-	// You can use AssertReporter, RequireReporter (they use testify),
-	// or *testing.T, or provide custom implementation.
-	// You can also Use FatalReporter that use testing.TB
+	// You can use:
+	// - AssertReporter / RequireReporter (non-fatal / fatal failures using testify package)
+	// - testing.T / FatalReporter (non-fatal / fatal failures 
+	//   using standard testing package)
+	// - custom implementation
 	Reporter Reporter
 
 	// Formatter is used to format success and failure messages.
@@ -310,7 +312,7 @@ type WebsocketDialer interface {
 }
 
 // Reporter is used to report failures.
-// *testing.T, AssertReporter, and RequireReporter implement this interface.
+// *testing.T, AssertReporter, FatalReporter and RequireReporter implement this interface.
 type Reporter interface {
 	// Errorf reports failure.
 	// Allowed to return normally or terminate test using t.FailNow().

--- a/expect.go
+++ b/expect.go
@@ -159,7 +159,7 @@ type Config struct {
 	//
 	// You can use:
 	// - AssertReporter / RequireReporter (non-fatal / fatal failures using testify package)
-	// - testing.T / FatalReporter (non-fatal / fatal failures 
+	// - testing.T / FatalReporter (non-fatal / fatal failures
 	//   using standard testing package)
 	// - custom implementation
 	Reporter Reporter

--- a/reporter.go
+++ b/reporter.go
@@ -53,6 +53,5 @@ func NewFatalReporter(backend testing.TB) *FatalReporter {
 
 // Errorf implements Reporter.Errorf.
 func (r *FatalReporter) Errorf(message string, args ...interface{}) {
-	r.backend.Logf(message, args...)
-	r.backend.Fail()
+	r.backend.Fatalf(message, args...)
 }

--- a/reporter.go
+++ b/reporter.go
@@ -51,7 +51,7 @@ func NewFatalReporter(backend testing.TB) *FatalReporter {
 	return &FatalReporter{backend}
 }
 
-// Errorf implements Reporter.Errorf.
+// Errorf implements Reporter.Errorf .
 func (r *FatalReporter) Errorf(message string, args ...interface{}) {
 	r.backend.Logf(message, args...)
 	r.backend.Fail()

--- a/reporter.go
+++ b/reporter.go
@@ -40,27 +40,19 @@ func (r *RequireReporter) Errorf(message string, args ...interface{}) {
 	r.backend.FailNow(fmt.Sprintf(message, args...))
 }
 
-// FatalReporter is a struct that implements the testing.Reporter interface
+// FatalReporter is a struct that implements the Reporter interface
 // and calls t.Fatalf() when a test fails.
 type FatalReporter struct {
 	backend testing.TB
 }
 
-// Errorf implements Reporter.Errorf.
-func (r *FatalReporter) Errorf(message string, args ...interface{}) {
-	r.backend.Fatalf(message, args...)
-}
-
-// Report is a method that takes a testing.TB interface and checks if the test
-// has failed by calling the Failed() method. If the test has failed, it calls
-// the Errorf method with the provided testing.TB interface and an error message.
-func (r *FatalReporter) Report(result testing.TB) {
-	if result.Failed() {
-		r.Errorf("Test failed")
-	}
-}
-
-// NeFatalReporter returns a new FatalReporter object.
+// NewFatalReporter returns a new FatalReporter object.
 func NewFatalReporter(backend testing.TB) *FatalReporter {
 	return &FatalReporter{backend}
+}
+
+// Errorf implements Reporter.Errorf.
+func (r *FatalReporter) Errorf(message string, args ...interface{}) {
+	r.backend.Logf(message, args...)
+	r.backend.Fail()
 }

--- a/reporter.go
+++ b/reporter.go
@@ -51,7 +51,7 @@ func NewFatalReporter(backend testing.TB) *FatalReporter {
 	return &FatalReporter{backend}
 }
 
-// Errorf implements Reporter.Errorf .
+// Errorf implements Reporter.Errorf.
 func (r *FatalReporter) Errorf(message string, args ...interface{}) {
 	r.backend.Logf(message, args...)
 	r.backend.Fail()

--- a/reporter.go
+++ b/reporter.go
@@ -42,25 +42,25 @@ func (r *RequireReporter) Errorf(message string, args ...interface{}) {
 
 // FatalReporter is a struct that implements the testing.Reporter interface
 // and calls t.Fatalf() when a test fails.
-type FatalReporter struct{
+type FatalReporter struct {
 	backend testing.TB
 }
 
 // Errorf implements Reporter.Errorf.
 func (r *FatalReporter) Errorf(message string, args ...interface{}) {
-    r.backend.Fatalf(message, args...)
+	r.backend.Fatalf(message, args...)
 }
 
 // Report is a method that takes a testing.TB interface and checks if the test
 // has failed by calling the Failed() method. If the test has failed, it calls
 // the Errorf method with the provided testing.TB interface and an error message.
 func (r *FatalReporter) Report(result testing.TB) {
-    if result.Failed() {
-        r.Errorf("Test failed")
-    }
+	if result.Failed() {
+		r.Errorf("Test failed")
+	}
 }
 
 // NeFatalReporter returns a new FatalReporter object.
 func NewFatalReporter(backend testing.TB) *FatalReporter {
-    return &FatalReporter{backend}
+	return &FatalReporter{backend}
 }

--- a/reporter.go
+++ b/reporter.go
@@ -2,6 +2,7 @@ package httpexpect
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,4 +38,29 @@ func NewRequireReporter(t require.TestingT) *RequireReporter {
 // Errorf implements Reporter.Errorf.
 func (r *RequireReporter) Errorf(message string, args ...interface{}) {
 	r.backend.FailNow(fmt.Sprintf(message, args...))
+}
+
+// FatalReporter is a struct that implements the testing.Reporter interface
+// and calls t.Fatalf() when a test fails.
+type FatalReporter struct{
+	backend testing.TB
+}
+
+// Errorf implements Reporter.Errorf.
+func (r *FatalReporter) Errorf(message string, args ...interface{}) {
+    r.backend.Fatalf(message, args...)
+}
+
+// Report is a method that takes a testing.TB interface and checks if the test
+// has failed by calling the Failed() method. If the test has failed, it calls
+// the Errorf method with the provided testing.TB interface and an error message.
+func (r *FatalReporter) Report(result testing.TB) {
+    if result.Failed() {
+        r.Errorf("Test failed")
+    }
+}
+
+// NeFatalReporter returns a new FatalReporter object.
+func NewFatalReporter(backend testing.TB) *FatalReporter {
+    return &FatalReporter{backend}
 }

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -4,12 +4,8 @@ import (
 	"testing"
 )
 
-type mockT struct {
-	testing.T
-}
-
 func TestFatalReporter(t *testing.T) {
-	mockBackend := &mockT{}
+	mockBackend := &testing.T{}
 	reporter := NewFatalReporter(mockBackend)
 
 	t.Run("Test Errorf", func(t *testing.T) {

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -2,16 +2,28 @@ package httpexpect
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
+type mockT struct {
+	testing.T
+}
+
+var fatalfInvoked = false
+
+func (m *mockT) Fatalf(format string, args ...interface{}) {
+	fatalfInvoked = true
+}
+
 func TestFatalReporter(t *testing.T) {
-	mockBackend := &testing.T{}
+	mockBackend := &mockT{}
 	reporter := NewFatalReporter(mockBackend)
 
 	t.Run("Test Errorf", func(t *testing.T) {
 		reporter.Errorf("Test failed with backend: %v", mockBackend)
 		if !mockBackend.Failed() {
-			t.Error("Test failed")
+			assert.True(t, fatalfInvoked)
 		}
 	})
 }

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -8,12 +8,11 @@ import (
 
 type mockT struct {
 	testing.T
+	fatalfInvoked bool
 }
 
-var fatalfInvoked = false
-
 func (m *mockT) Fatalf(format string, args ...interface{}) {
-	fatalfInvoked = true
+	m.fatalfInvoked = true
 }
 
 func TestFatalReporter(t *testing.T) {
@@ -22,8 +21,6 @@ func TestFatalReporter(t *testing.T) {
 
 	t.Run("Test Errorf", func(t *testing.T) {
 		reporter.Errorf("Test failed with backend: %v", mockBackend)
-		if !mockBackend.Failed() {
-			assert.True(t, fatalfInvoked)
-		}
+		assert.True(t, mockBackend.fatalfInvoked)
 	})
 }

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -1,0 +1,21 @@
+package httpexpect
+
+import (
+	"testing"
+)
+
+type mockT struct {
+	testing.T
+}
+
+func TestFatalReporter(t *testing.T) {
+	mockBackend := &mockT{}
+	reporter := NewFatalReporter(mockBackend)
+
+	t.Run("Test Errorf", func(t *testing.T) {
+		reporter.Errorf("Test failed with backend: %v", mockBackend)
+		if !mockBackend.Failed() {
+			t.Error("Test failed")
+		}
+	})
+}


### PR DESCRIPTION
Implementation of FatalReporter that raises an exception when a test fails, which will stop the execution of the test suite immediately and alert you of a failure