### PR TITLE
Add InList and NotInList

### DIFF
--- a/array.go
+++ b/array.go
@@ -776,10 +776,6 @@ func (a *Array) InList(values ...interface{}) *Array {
 		return a
 	}
 
-	if len(arr) == 1 {
-		return a.IsEqual(arr[0])
-	}
-
 	var isListed bool
 	for _, v := range values {
 		expected, ok := canonArray(opChain, v)
@@ -834,10 +830,6 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 	arr, ok := canonArray(opChain, values)
 	if !ok {
 		return a
-	}
-
-	if len(arr) == 1 {
-		return a.NotEqual(arr[0])
 	}
 
 	var isListed bool

--- a/array.go
+++ b/array.go
@@ -750,8 +750,7 @@ func (a *Array) Equal(value interface{}) *Array {
 // Before comparison, both array and value are converted to canonical form.
 //
 // values should be an array of slice of any type. This comparison adheres
-// element order. For values with length 1, it behaves the same way with
-// IsEqual.
+// element order.
 //
 // Example:
 //
@@ -812,8 +811,7 @@ func (a *Array) InList(values ...interface{}) *Array {
 // Before comparison, both array and value are converted to canonical form.
 //
 // values should be an array of slice of any type. This comparison adheres
-// element order. For values with length 1, it behaves the same way with
-// NotEqual.
+// element order.
 //
 // Example:
 //

--- a/array.go
+++ b/array.go
@@ -771,8 +771,14 @@ func (a *Array) InList(values ...interface{}) *Array {
 		return a
 	}
 
-	arr, ok := canonArray(opChain, values)
-	if !ok {
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return a
 	}
 
@@ -792,7 +798,7 @@ func (a *Array) InList(values ...interface{}) *Array {
 		opChain.fail(AssertionFailure{
 			Type:     AssertBelongs,
 			Actual:   &AssertionValue{a.value},
-			Expected: &AssertionValue{AssertionList(arr)},
+			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
 				errors.New("expected: arrays are listed"),
 			},
@@ -827,13 +833,19 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 		return a
 	}
 
-	arr, ok := canonArray(opChain, values)
-	if !ok {
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return a
 	}
 
 	var isListed bool
-	for _, v := range arr {
+	for _, v := range values {
 		expected, ok := canonArray(opChain, v)
 		if !ok {
 			return a
@@ -848,7 +860,7 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 		opChain.fail(AssertionFailure{
 			Type:     AssertNotBelongs,
 			Actual:   &AssertionValue{a.value},
-			Expected: &AssertionValue{AssertionList(arr)},
+			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
 				errors.New("expected: arrays are not listed"),
 			},

--- a/array.go
+++ b/array.go
@@ -746,22 +746,17 @@ func (a *Array) Equal(value interface{}) *Array {
 	return a.IsEqual(value)
 }
 
-// InList succeeds if array is listed by given [values...].
-// Before comparison, both array and value are converted to canonical form.
+// InList succeeds if whole array is equal to one of the elements from given
+// list of arrays.
+// Before comparison, both array and each value are converted to canonical
+// form.
 //
-// values should be an array of slice of any type. This comparison adheres
-// element order.
+// Each value should be a slice of any type.
 //
 // Example:
 //
 //	array := NewArray(t, []interface{}{"foo", 123})
-//	array.InList([]interface{}{"foo", 123})
-//
-//	array := NewArray(t, []interface{}{"foo", "bar"})
-//	array.InList([]string{}{"foo", "bar"})
-//
-//	array := NewArray(t, []interface{}{123, 456})
-//	array.InList([]int{}{123, 456})
+//	array.InList([]interface{}{"foo", 123}, []interface{}{"bar", "456"})
 func (a *Array) InList(values ...interface{}) *Array {
 	opChain := a.chain.enter("InList()")
 	defer opChain.leave()
@@ -799,7 +794,7 @@ func (a *Array) InList(values ...interface{}) *Array {
 			Actual:   &AssertionValue{a.value},
 			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
-				errors.New("expected: arrays are listed"),
+				errors.New("expected: arrays is equal to one of the values"),
 			},
 		})
 	}
@@ -807,22 +802,17 @@ func (a *Array) InList(values ...interface{}) *Array {
 	return a
 }
 
-// NotInList succeeds if array is not listed by given [values...].
-// Before comparison, both array and value are converted to canonical form.
+// NotInList succeeds if whole array is not equal to any of the elements
+// from given list of arrays.
+// Before comparison, both array and each value are converted to canonical
+// form.
 //
-// values should be an array of slice of any type. This comparison adheres
-// element order.
+// Each value should be a slice of any type.
 //
 // Example:
 //
 //	array := NewArray(t, []interface{}{"foo", 123})
-//	array.NotInList([]interface{}{"bar", 456})
-//
-//	array := NewArray(t, []interface{}{"foo", "bar"})
-//	array.NotInList([]string{}{"bar", "foo"})
-//
-//	array := NewArray(t, []interface{}{123, 456})
-//	array.NotInList([]int{}{789, 901})
+//	array.NotInList([]interface{}{"bar", 456}, []interface{}{"baz", "foo"})
 func (a *Array) NotInList(values ...interface{}) *Array {
 	opChain := a.chain.enter("NotInList()")
 	defer opChain.leave()
@@ -860,7 +850,7 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 			Actual:   &AssertionValue{a.value},
 			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
-				errors.New("expected: arrays are not listed"),
+				errors.New("expected: arrays is not equal to any of the values"),
 			},
 		})
 	}

--- a/array.go
+++ b/array.go
@@ -750,7 +750,8 @@ func (a *Array) Equal(value interface{}) *Array {
 // Before comparison, both array and value are converted to canonical form.
 //
 // values should be an array of slice of any type. This comparison adheres
-// element order.
+// element order. For values with length 1, it behaves the same way with
+// IsEqual.
 //
 // Example:
 //
@@ -770,8 +771,13 @@ func (a *Array) InList(values ...interface{}) *Array {
 		return a
 	}
 
-	if len(values) <= 1 {
-		return a.IsEqual(values[0])
+	arr, ok := canonArray(opChain, values)
+	if !ok {
+		return a
+	}
+
+	if len(arr) == 1 {
+		return a.IsEqual(arr[0])
 	}
 
 	var isListed bool
@@ -790,7 +796,7 @@ func (a *Array) InList(values ...interface{}) *Array {
 		opChain.fail(AssertionFailure{
 			Type:     AssertBelongs,
 			Actual:   &AssertionValue{a.value},
-			Expected: &AssertionValue{AssertionList(values)},
+			Expected: &AssertionValue{AssertionList(arr)},
 			Errors: []error{
 				errors.New("expected: arrays are listed"),
 			},
@@ -804,7 +810,8 @@ func (a *Array) InList(values ...interface{}) *Array {
 // Before comparison, both array and value are converted to canonical form.
 //
 // values should be an array of slice of any type. This comparison adheres
-// element order.
+// element order. For values with length 1, it behaves the same way with
+// NotEqual.
 //
 // Example:
 //
@@ -824,12 +831,17 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 		return a
 	}
 
-	if len(values) <= 1 {
-		return a.NotEqual(values[0])
+	arr, ok := canonArray(opChain, values)
+	if !ok {
+		return a
+	}
+
+	if len(arr) == 1 {
+		return a.NotEqual(arr[0])
 	}
 
 	var isListed bool
-	for _, v := range values {
+	for _, v := range arr {
 		expected, ok := canonArray(opChain, v)
 		if !ok {
 			return a
@@ -844,7 +856,7 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 		opChain.fail(AssertionFailure{
 			Type:     AssertNotBelongs,
 			Actual:   &AssertionValue{a.value},
-			Expected: &AssertionValue{AssertionList(values)},
+			Expected: &AssertionValue{AssertionList(arr)},
 			Errors: []error{
 				errors.New("expected: arrays are not listed"),
 			},

--- a/array.go
+++ b/array.go
@@ -785,6 +785,7 @@ func (a *Array) InList(values ...interface{}) *Array {
 
 		if reflect.DeepEqual(expected, a.value) {
 			isListed = true
+			break
 		}
 	}
 
@@ -832,7 +833,6 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 		return a
 	}
 
-	var isListed bool
 	for _, v := range values {
 		expected, ok := canonArray(opChain, v)
 		if !ok {
@@ -840,19 +840,16 @@ func (a *Array) NotInList(values ...interface{}) *Array {
 		}
 
 		if reflect.DeepEqual(expected, a.value) {
-			isListed = true
+			opChain.fail(AssertionFailure{
+				Type:     AssertNotBelongs,
+				Actual:   &AssertionValue{a.value},
+				Expected: &AssertionValue{AssertionList(values)},
+				Errors: []error{
+					errors.New("expected: arrays is not equal to any of the values"),
+				},
+			})
+			break
 		}
-	}
-
-	if isListed {
-		opChain.fail(AssertionFailure{
-			Type:     AssertNotBelongs,
-			Actual:   &AssertionValue{a.value},
-			Expected: &AssertionValue{AssertionList(values)},
-			Errors: []error{
-				errors.New("expected: arrays is not equal to any of the values"),
-			},
-		})
 	}
 
 	return a

--- a/array_test.go
+++ b/array_test.go
@@ -433,14 +433,6 @@ func TestArray_InList(t *testing.T) {
 	value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
-
-	value.InList([]interface{}{"foo", "bar"}, "foo")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList([]interface{}{"foo", "bar"}, "foo")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
 }
 
 func TestArray_EqualTypes(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -386,19 +386,19 @@ func TestArray_InList(t *testing.T) {
 
 	assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
 
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
 	value.InList([]interface{}{})
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 
 	value.NotInList([]interface{}{})
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.InList([]interface{}{"foo"})
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList([]interface{}{"foo"})
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 

--- a/array_test.go
+++ b/array_test.go
@@ -31,6 +31,8 @@ func TestArray_Failed(t *testing.T) {
 		value.NotEmpty()
 		value.IsEqual([]interface{}{})
 		value.NotEqual([]interface{}{})
+		value.InList([]interface{}{})
+		value.NotInList([]interface{}{})
 		value.IsEqualUnordered([]interface{}{})
 		value.NotEqualUnordered([]interface{}{})
 		value.ConsistsOf("foo")
@@ -373,6 +375,62 @@ func TestArray_EqualNotEmpty(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.NotEqual([]interface{}{"foo", "bar"})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+}
+
+func TestArray_InList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewArray(reporter, []interface{}{"foo", "bar"})
+
+	assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
+
+	value.InList([]interface{}{})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList([]interface{}{})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList([]interface{}{"foo"})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList([]interface{}{"foo"})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList([]interface{}{"bar", "foo"})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList([]interface{}{"bar", "foo"})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList([]interface{}{"bar", "foo"}, []interface{}{"foo", "bar"})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"foo", "bar"})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList([]interface{}{"foo", "bar"}, "foo")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList([]interface{}{"foo", "bar"}, "foo")
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 }

--- a/array_test.go
+++ b/array_test.go
@@ -394,6 +394,14 @@ func TestArray_InList(t *testing.T) {
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 
+	value.InList("foo", "bar")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList("foo", "bar")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
 	value.InList([]interface{}{})
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()

--- a/assertion_test.go
+++ b/assertion_test.go
@@ -336,18 +336,6 @@ func TestAssertion_ValidateTraits(t *testing.T) {
 				List: fieldRequired,
 			},
 		},
-		{
-			testName:          "AssertionList should not be slice of single element",
-			errorContainsText: "AssertionList",
-			failure: AssertionFailure{
-				Expected: &AssertionValue{
-					Value: AssertionList{[]int{1}},
-				},
-			},
-			traits: fieldTraits{
-				List: fieldRequired,
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -625,18 +613,6 @@ func TestAssertion_ValidateAssertion(t *testing.T) {
 				},
 				Actual:   &AssertionValue{},
 				Expected: &AssertionValue{AssertionList{}},
-			},
-		},
-		{
-			testName:          "List has one element and it's list",
-			errorContainsText: "AssertionList",
-			input: AssertionFailure{
-				Type: AssertBelongs,
-				Errors: []error{
-					errors.New("test"),
-				},
-				Actual:   &AssertionValue{},
-				Expected: &AssertionValue{AssertionList{[]string{"test"}}},
 			},
 		},
 	}

--- a/assertion_validation.go
+++ b/assertion_validation.go
@@ -3,7 +3,6 @@ package httpexpect
 import (
 	"errors"
 	"fmt"
-	"reflect"
 )
 
 func validateAssertion(failure *AssertionFailure) error {
@@ -181,12 +180,6 @@ func validateTraits(failure *AssertionFailure, traits fieldTraits) error {
 			if lst, ok := failure.Expected.Value.(AssertionList); ok {
 				if len(lst) == 0 {
 					return errors.New("AssertionList should be non-empty")
-				}
-
-				if len(lst) == 1 && reflect.ValueOf(lst[0]).Kind() == reflect.Slice {
-					return errors.New(
-						"AssertionList should contain a list of values," +
-							" but it contains a single element which itself is a list")
 				}
 			}
 		}

--- a/boolean.go
+++ b/boolean.go
@@ -176,6 +176,17 @@ func (b *Boolean) InList(values ...bool) *Boolean {
 		return b
 	}
 
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return b
+	}
+
 	for _, v := range values {
 		if b.value == v {
 			return b
@@ -205,6 +216,17 @@ func (b *Boolean) NotInList(values ...bool) *Boolean {
 	defer opChain.leave()
 
 	if opChain.failed() {
+		return b
+	}
+
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return b
 	}
 

--- a/boolean.go
+++ b/boolean.go
@@ -162,7 +162,8 @@ func (b *Boolean) Equal(value bool) *Boolean {
 	return b.IsEqual(value)
 }
 
-// InList succeeds if boolean is listed by given [values...].
+// InList succeeds if boolean is equal to one of the elements from given
+// list of booleans.
 //
 // Example:
 //
@@ -198,14 +199,15 @@ func (b *Boolean) InList(values ...bool) *Boolean {
 		Actual:   &AssertionValue{b.value},
 		Expected: &AssertionValue{AssertionList(boolList(values))},
 		Errors: []error{
-			errors.New("expected: boolean is listed"),
+			errors.New("expected: boolean is equal to one of the values"),
 		},
 	})
 
 	return b
 }
 
-// NotInList succeeds if boolean is not listed by given [values...].
+// NotInList succeeds if boolean is not equal to any of the elements from
+// given list of booleans.
 //
 // Example:
 //
@@ -237,7 +239,7 @@ func (b *Boolean) NotInList(values ...bool) *Boolean {
 				Actual:   &AssertionValue{b.value},
 				Expected: &AssertionValue{AssertionList(boolList(values))},
 				Errors: []error{
-					errors.New("expected: boolean is not listed"),
+					errors.New("expected: boolean is not equal to any of the values"),
 				},
 			})
 		}

--- a/boolean.go
+++ b/boolean.go
@@ -188,20 +188,24 @@ func (b *Boolean) InList(values ...bool) *Boolean {
 		return b
 	}
 
+	var isListed bool
 	for _, v := range values {
 		if b.value == v {
-			return b
+			isListed = true
+			break
 		}
 	}
 
-	opChain.fail(AssertionFailure{
-		Type:     AssertBelongs,
-		Actual:   &AssertionValue{b.value},
-		Expected: &AssertionValue{AssertionList(boolList(values))},
-		Errors: []error{
-			errors.New("expected: boolean is equal to one of the values"),
-		},
-	})
+	if !isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertBelongs,
+			Actual:   &AssertionValue{b.value},
+			Expected: &AssertionValue{AssertionList(boolList(values))},
+			Errors: []error{
+				errors.New("expected: boolean is equal to one of the values"),
+			},
+		})
+	}
 
 	return b
 }
@@ -242,6 +246,7 @@ func (b *Boolean) NotInList(values ...bool) *Boolean {
 					errors.New("expected: boolean is not equal to any of the values"),
 				},
 			})
+			break
 		}
 	}
 

--- a/boolean.go
+++ b/boolean.go
@@ -253,15 +253,6 @@ func (b *Boolean) NotInList(values ...bool) *Boolean {
 	return b
 }
 
-func boolList(values []bool) []interface{} {
-	l := make([]interface{}, 0, len(values))
-	for _, v := range values {
-		l = append(l, v)
-	}
-
-	return l
-}
-
 // True succeeds if boolean is true.
 //
 // Example:
@@ -316,4 +307,13 @@ func (b *Boolean) False() *Boolean {
 	}
 
 	return b
+}
+
+func boolList(values []bool) []interface{} {
+	l := make([]interface{}, 0, len(values))
+	for _, v := range values {
+		l = append(l, v)
+	}
+
+	return l
 }

--- a/boolean.go
+++ b/boolean.go
@@ -162,6 +162,77 @@ func (b *Boolean) Equal(value bool) *Boolean {
 	return b.IsEqual(value)
 }
 
+// InList succeeds if boolean is listed by given [values...].
+//
+// Example:
+//
+//	boolean := NewBoolean(t, true)
+//	boolean.InList(true, false)
+func (b *Boolean) InList(values ...bool) *Boolean {
+	opChain := b.chain.enter("InList()")
+	defer opChain.leave()
+
+	if opChain.failed() {
+		return b
+	}
+
+	for _, v := range values {
+		if b.value == v {
+			return b
+		}
+	}
+
+	opChain.fail(AssertionFailure{
+		Type:     AssertBelongs,
+		Actual:   &AssertionValue{b.value},
+		Expected: &AssertionValue{AssertionList(boolList(values))},
+		Errors: []error{
+			errors.New("expected: boolean is listed"),
+		},
+	})
+
+	return b
+}
+
+// NotInList succeeds if boolean is not listed by given [values...].
+//
+// Example:
+//
+//	boolean := NewBoolean(t, true)
+//	boolean.NotInList(true, false)
+func (b *Boolean) NotInList(values ...bool) *Boolean {
+	opChain := b.chain.enter("NotInList()")
+	defer opChain.leave()
+
+	if opChain.failed() {
+		return b
+	}
+
+	for _, v := range values {
+		if b.value == v {
+			opChain.fail(AssertionFailure{
+				Type:     AssertNotBelongs,
+				Actual:   &AssertionValue{b.value},
+				Expected: &AssertionValue{AssertionList(boolList(values))},
+				Errors: []error{
+					errors.New("expected: boolean is not listed"),
+				},
+			})
+		}
+	}
+
+	return b
+}
+
+func boolList(values []bool) []interface{} {
+	l := make([]interface{}, 0, len(values))
+	for _, v := range values {
+		l = append(l, v)
+	}
+
+	return l
+}
+
 // True succeeds if boolean is true.
 //
 // Example:

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -211,3 +211,17 @@ func TestBoolean_False(t *testing.T) {
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 }
+
+func TestBoolean_ZeroLengthInList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewBoolean(reporter, true)
+
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+}

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -21,6 +21,8 @@ func TestBoolean_Failed(t *testing.T) {
 
 	value.IsEqual(false)
 	value.NotEqual(false)
+	value.InList(false)
+	value.NotInList(false)
 	value.True()
 	value.False()
 }
@@ -160,6 +162,14 @@ func TestBoolean_True(t *testing.T) {
 	value.False()
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
+
+	value.InList(true, true)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(true, false)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 }
 
 func TestBoolean_False(t *testing.T) {
@@ -190,6 +200,14 @@ func TestBoolean_False(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.False()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(true, true)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(true, true)
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 }

--- a/datetime.go
+++ b/datetime.go
@@ -448,20 +448,24 @@ func (dt *DateTime) InList(values ...time.Time) *DateTime {
 		return dt
 	}
 
+	var isListed bool
 	for _, v := range values {
 		if dt.value.Equal(v) {
-			return dt
+			isListed = true
+			break
 		}
 	}
 
-	opChain.fail(AssertionFailure{
-		Type:     AssertBelongs,
-		Actual:   &AssertionValue{dt.value},
-		Expected: &AssertionValue{AssertionList(timeList(values))},
-		Errors: []error{
-			errors.New("expected: time point is equal to one of the values"),
-		},
-	})
+	if !isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertBelongs,
+			Actual:   &AssertionValue{dt.value},
+			Expected: &AssertionValue{AssertionList(timeList(values))},
+			Errors: []error{
+				errors.New("expected: time point is equal to one of the values"),
+			},
+		})
+	}
 
 	return dt
 }
@@ -502,6 +506,7 @@ func (dt *DateTime) NotInList(values ...time.Time) *DateTime {
 					errors.New("expected: time point is not equal to any of the values"),
 				},
 			})
+			break
 		}
 	}
 

--- a/datetime.go
+++ b/datetime.go
@@ -422,7 +422,8 @@ func (dt *DateTime) NotInRange(min, max time.Time) *DateTime {
 	return dt
 }
 
-// InList succeeds if DateTime is listed by given [values...].
+// InList succeeds if DateTime is equal to one of the elements from given
+// list of time.Time.
 //
 // Example:
 //
@@ -458,14 +459,15 @@ func (dt *DateTime) InList(values ...time.Time) *DateTime {
 		Actual:   &AssertionValue{dt.value},
 		Expected: &AssertionValue{AssertionList(timeList(values))},
 		Errors: []error{
-			errors.New("expected: time point is listed"),
+			errors.New("expected: time point is equal to one of the values"),
 		},
 	})
 
 	return dt
 }
 
-// NotInList succeeds if DateTime is not listed by given [values...].
+// NotInList succeeds if DateTime is not equal to any of the elements from
+// given list of time.Time.
 //
 // Example:
 //
@@ -497,7 +499,7 @@ func (dt *DateTime) NotInList(values ...time.Time) *DateTime {
 				Actual:   &AssertionValue{dt.value},
 				Expected: &AssertionValue{AssertionList(timeList(values))},
 				Errors: []error{
-					errors.New("expected: time point is not listed"),
+					errors.New("expected: time point is not equal to any of the values"),
 				},
 			})
 		}

--- a/datetime.go
+++ b/datetime.go
@@ -436,6 +436,17 @@ func (dt *DateTime) InList(values ...time.Time) *DateTime {
 		return dt
 	}
 
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return dt
+	}
+
 	for _, v := range values {
 		if dt.value.Equal(v) {
 			return dt
@@ -465,6 +476,17 @@ func (dt *DateTime) NotInList(values ...time.Time) *DateTime {
 	defer opChain.leave()
 
 	if opChain.failed() {
+		return dt
+	}
+
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return dt
 	}
 

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -252,6 +252,14 @@ func TestDateTime_InList(t *testing.T) {
 
 	value := NewDateTime(reporter, time.Unix(0, 1234))
 
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
 	value.InList(time.Unix(0, 1234), time.Unix(0, 1234))
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -25,6 +25,8 @@ func TestDateTime_Failed(t *testing.T) {
 	value.Le(tm)
 	value.InRange(tm, tm)
 	value.NotInRange(tm, tm)
+	value.InList(tm, tm)
+	value.NotInList(tm, tm)
 	value.Zone()
 	value.Year()
 	value.Month()
@@ -241,6 +243,60 @@ func TestDateTime_InRange(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.NotInRange(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+}
+
+func TestDateTime_InList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewDateTime(reporter, time.Unix(0, 1234))
+
+	value.InList(time.Unix(0, 1234), time.Unix(0, 1234))
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Unix(0, 1234), time.Unix(0, 1234))
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Unix(0, 1234-1), time.Unix(0, 1234))
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Unix(0, 1234-1), time.Unix(0, 1234))
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Unix(0, 1234), time.Unix(0, 1234+1))
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Unix(0, 1234), time.Unix(0, 1234+1))
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 }

--- a/duration.go
+++ b/duration.go
@@ -444,6 +444,17 @@ func (d *Duration) InList(values ...time.Duration) *Duration {
 		return d
 	}
 
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return d
+	}
+
 	if d.value == nil {
 		opChain.fail(AssertionFailure{
 			Type:   AssertNotNil,
@@ -484,6 +495,17 @@ func (d *Duration) NotInList(values ...time.Duration) *Duration {
 	defer opChain.leave()
 
 	if opChain.failed() {
+		return d
+	}
+
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return d
 	}
 

--- a/duration.go
+++ b/duration.go
@@ -430,7 +430,8 @@ func (d *Duration) NotInRange(min, max time.Duration) *Duration {
 	return d
 }
 
-// InList succeeds if Duration is listed by given duration [values...].
+// InList succeeds if Duration is equal to one of the elements from given
+// list of time.Duration.
 //
 // Example:
 //
@@ -477,14 +478,15 @@ func (d *Duration) InList(values ...time.Duration) *Duration {
 		Actual:   &AssertionValue{d.value},
 		Expected: &AssertionValue{AssertionList(durationList(values))},
 		Errors: []error{
-			errors.New("expected: duration is listed"),
+			errors.New("expected: duration is equal to one of the values"),
 		},
 	})
 
 	return d
 }
 
-// NotInList succeeds if Duration is not listed by given duration [values...].
+// NotInList succeeds if Duration is not equal to any of the elements from
+// given list of time.Duration.
 //
 // Example:
 //
@@ -528,7 +530,7 @@ func (d *Duration) NotInList(values ...time.Duration) *Duration {
 				Actual:   &AssertionValue{d.value},
 				Expected: &AssertionValue{AssertionList(durationList(values))},
 				Errors: []error{
-					errors.New("expected: duration is not listed"),
+					errors.New("expected: duration is not equal to any of the values"),
 				},
 			})
 		}

--- a/duration.go
+++ b/duration.go
@@ -467,20 +467,24 @@ func (d *Duration) InList(values ...time.Duration) *Duration {
 		return d
 	}
 
+	var isListed bool
 	for _, v := range values {
 		if *d.value == v {
-			return d
+			isListed = true
+			break
 		}
 	}
 
-	opChain.fail(AssertionFailure{
-		Type:     AssertBelongs,
-		Actual:   &AssertionValue{d.value},
-		Expected: &AssertionValue{AssertionList(durationList(values))},
-		Errors: []error{
-			errors.New("expected: duration is equal to one of the values"),
-		},
-	})
+	if !isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertBelongs,
+			Actual:   &AssertionValue{d.value},
+			Expected: &AssertionValue{AssertionList(durationList(values))},
+			Errors: []error{
+				errors.New("expected: duration is equal to one of the values"),
+			},
+		})
+	}
 
 	return d
 }
@@ -533,6 +537,7 @@ func (d *Duration) NotInList(values ...time.Duration) *Duration {
 					errors.New("expected: duration is not equal to any of the values"),
 				},
 			})
+			break
 		}
 	}
 

--- a/duration_test.go
+++ b/duration_test.go
@@ -229,10 +229,18 @@ func TestDuration_InRange(t *testing.T) {
 func TestDuration_InList(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	newDuration(newMockChain(t), nil).InList().chain.assertFailed(t)
-	newDuration(newMockChain(t), nil).NotInList().chain.assertFailed(t)
+	newDuration(newMockChain(t), nil).InList(time.Second).chain.assertFailed(t)
+	newDuration(newMockChain(t), nil).NotInList(time.Second).chain.assertFailed(t)
 
 	value := NewDuration(reporter, time.Second)
+
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
 	value.InList(time.Second, time.Minute)
 	value.chain.assertNotFailed(t)

--- a/duration_test.go
+++ b/duration_test.go
@@ -16,6 +16,8 @@ func TestDuration_Failed(t *testing.T) {
 
 	value.IsEqual(tm)
 	value.NotEqual(tm)
+	value.InList(tm)
+	value.NotInList(tm)
 	value.Gt(tm)
 	value.Ge(tm)
 	value.Lt(tm)
@@ -220,6 +222,47 @@ func TestDuration_InRange(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.NotInRange(time.Second+1, time.Second-1)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+}
+
+func TestDuration_InList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	newDuration(newMockChain(t), nil).InList().chain.assertFailed(t)
+	newDuration(newMockChain(t), nil).NotInList().chain.assertFailed(t)
+
+	value := NewDuration(reporter, time.Second)
+
+	value.InList(time.Second, time.Minute)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Second, time.Minute)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Second-1, time.Minute)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Second-1, time.Minute)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Second, time.Second+1)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Second, time.Second+1)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(time.Second+1, time.Second-1)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(time.Second+1, time.Second-1)
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 }

--- a/number.go
+++ b/number.go
@@ -366,6 +366,96 @@ func (n *Number) NotInRange(min, max interface{}) *Number {
 	return n
 }
 
+// InList succeeds if number is listed by given [values...].
+//
+// values should have array of numeric type convertible to float64. Before
+// comparison, it is converted to float64.
+//
+// Example:
+//
+//	number := NewNumber(t, 123)
+//	number.InList(float64(123), int32(123))
+func (n *Number) InList(values ...interface{}) *Number {
+	opChain := n.chain.enter("IsList()")
+	defer opChain.leave()
+
+	if opChain.failed() {
+		return n
+	}
+
+	arr, _ := canonArray(opChain, values)
+
+	var isListed bool
+	for _, v := range arr {
+		num, ok := canonNumber(opChain, v)
+		if !ok {
+			return n
+		}
+
+		if n.value == num {
+			isListed = true
+		}
+	}
+
+	if !isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertBelongs,
+			Actual:   &AssertionValue{n.value},
+			Expected: &AssertionValue{AssertionList(values)},
+			Errors: []error{
+				errors.New("expected: number is listed"),
+			},
+		})
+	}
+
+	return n
+}
+
+// NotInList succeeds if number is listed by given [values...].
+//
+// values should have array of numeric type convertible to float64. Before
+// comparison, it is converted to float64.
+//
+// Example:
+//
+//	number := NewNumber(t, 123)
+//	number.NotInList(float64(456), int32(456))
+func (n *Number) NotInList(values ...interface{}) *Number {
+	opChain := n.chain.enter("NotInList()")
+	defer opChain.leave()
+
+	if opChain.failed() {
+		return n
+	}
+
+	arr, _ := canonArray(opChain, values)
+
+	var isListed bool
+	for _, v := range arr {
+		num, ok := canonNumber(opChain, v)
+		if !ok {
+			return n
+		}
+
+		if n.value == num {
+			isListed = true
+		}
+	}
+
+	if isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertNotBelongs,
+			Actual:   &AssertionValue{n.value},
+			Expected: &AssertionValue{AssertionList(values)},
+			Errors: []error{
+				errors.New("expected: number is not listed"),
+			},
+		})
+	}
+
+	return n
+}
+
 // Gt succeeds if number is greater than given value.
 //
 // value should have numeric type convertible to float64. Before comparison,

--- a/number.go
+++ b/number.go
@@ -404,6 +404,7 @@ func (n *Number) InList(values ...interface{}) *Number {
 
 		if n.value == num {
 			isListed = true
+			break
 		}
 	}
 
@@ -450,7 +451,6 @@ func (n *Number) NotInList(values ...interface{}) *Number {
 		return n
 	}
 
-	var isListed bool
 	for _, v := range values {
 		num, ok := canonNumber(opChain, v)
 		if !ok {
@@ -458,19 +458,16 @@ func (n *Number) NotInList(values ...interface{}) *Number {
 		}
 
 		if n.value == num {
-			isListed = true
+			opChain.fail(AssertionFailure{
+				Type:     AssertNotBelongs,
+				Actual:   &AssertionValue{n.value},
+				Expected: &AssertionValue{AssertionList(values)},
+				Errors: []error{
+					errors.New("expected: number is not equal to any of the values"),
+				},
+			})
+			break
 		}
-	}
-
-	if isListed {
-		opChain.fail(AssertionFailure{
-			Type:     AssertNotBelongs,
-			Actual:   &AssertionValue{n.value},
-			Expected: &AssertionValue{AssertionList(values)},
-			Errors: []error{
-				errors.New("expected: number is not equal to any of the values"),
-			},
-		})
 	}
 
 	return n

--- a/number.go
+++ b/number.go
@@ -366,10 +366,11 @@ func (n *Number) NotInRange(min, max interface{}) *Number {
 	return n
 }
 
-// InList succeeds if number is listed by given [values...].
+// InList succeeds if number is equal to one of the elements from given
+// list of numbers.
+// Before comparison, each value is converted to canonical form.
 //
-// values should have array of numeric type convertible to float64. Before
-// comparison, it is converted to float64.
+// Each value should be numeric type convertible to float64.
 //
 // Example:
 //
@@ -412,7 +413,7 @@ func (n *Number) InList(values ...interface{}) *Number {
 			Actual:   &AssertionValue{n.value},
 			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
-				errors.New("expected: number is listed"),
+				errors.New("expected: number is equal to one of the values"),
 			},
 		})
 	}
@@ -420,10 +421,11 @@ func (n *Number) InList(values ...interface{}) *Number {
 	return n
 }
 
-// NotInList succeeds if number is listed by given [values...].
+// NotInList succeeds if whole array is not equal to any of the elements
+// from given list of numbers.
+// Before comparison, each value is converted to canonical form.
 //
-// values should have array of numeric type convertible to float64. Before
-// comparison, it is converted to float64.
+// Each value should be numeric type convertible to float64.
 //
 // Example:
 //
@@ -466,7 +468,7 @@ func (n *Number) NotInList(values ...interface{}) *Number {
 			Actual:   &AssertionValue{n.value},
 			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
-				errors.New("expected: number is not listed"),
+				errors.New("expected: number is not equal to any of the values"),
 			},
 		})
 	}

--- a/number.go
+++ b/number.go
@@ -383,10 +383,19 @@ func (n *Number) InList(values ...interface{}) *Number {
 		return n
 	}
 
-	arr, _ := canonArray(opChain, values)
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return n
+	}
 
 	var isListed bool
-	for _, v := range arr {
+	for _, v := range values {
 		num, ok := canonNumber(opChain, v)
 		if !ok {
 			return n
@@ -428,10 +437,19 @@ func (n *Number) NotInList(values ...interface{}) *Number {
 		return n
 	}
 
-	arr, _ := canonArray(opChain, values)
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return n
+	}
 
 	var isListed bool
-	for _, v := range arr {
+	for _, v := range values {
 		num, ok := canonNumber(opChain, v)
 		if !ok {
 			return n

--- a/number_test.go
+++ b/number_test.go
@@ -316,6 +316,14 @@ func TestNumber_InList(t *testing.T) {
 
 	value := NewNumber(reporter, 1234)
 
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
 	value.InList(1234, 4567)
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()

--- a/number_test.go
+++ b/number_test.go
@@ -22,6 +22,8 @@ func TestNumber_Failed(t *testing.T) {
 
 	value.IsEqual(0)
 	value.NotEqual(0)
+	value.InList(0)
+	value.NotInList(0)
 	value.InDelta(0, 0)
 	value.NotInDelta(0, 0)
 	value.Gt(0)
@@ -305,6 +307,44 @@ func TestNumber_InRange(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.NotInRange("1234+1", 1234+2)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+}
+
+func TestNumber_InList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewNumber(reporter, 1234)
+
+	value.InList(1234, 4567)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(1234, 4567)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(1234.00, 4567.00)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(1234.00, 4567.00)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(4567.00, 1234.01)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(4567.00, 1234.01)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(1234+1, "1234")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList("1234+1", 1234+2)
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 }

--- a/object.go
+++ b/object.go
@@ -761,10 +761,19 @@ func (o *Object) InList(values ...interface{}) *Object {
 		return o
 	}
 
-	arr, _ := canonArray(opChain, values)
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return o
+	}
 
 	var isListed bool
-	for _, v := range arr {
+	for _, v := range values {
 		expected, ok := canonMap(opChain, v)
 		if !ok {
 			return o
@@ -806,10 +815,19 @@ func (o *Object) NotInList(values ...interface{}) *Object {
 		return o
 	}
 
-	arr, _ := canonArray(opChain, values)
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return o
+	}
 
 	var isListed bool
-	for _, v := range arr {
+	for _, v := range values {
 		expected, ok := canonMap(opChain, v)
 		if !ok {
 			return o

--- a/object.go
+++ b/object.go
@@ -785,6 +785,7 @@ func (o *Object) InList(values ...interface{}) *Object {
 
 		if reflect.DeepEqual(expected, o.value) {
 			isListed = true
+			break
 		}
 	}
 
@@ -834,7 +835,6 @@ func (o *Object) NotInList(values ...interface{}) *Object {
 		return o
 	}
 
-	var isListed bool
 	for _, v := range values {
 		expected, ok := canonMap(opChain, v)
 		if !ok {
@@ -842,19 +842,16 @@ func (o *Object) NotInList(values ...interface{}) *Object {
 		}
 
 		if reflect.DeepEqual(expected, o.value) {
-			isListed = true
+			opChain.fail(AssertionFailure{
+				Type:     AssertNotBelongs,
+				Actual:   &AssertionValue{o.value},
+				Expected: &AssertionValue{AssertionList(values)},
+				Errors: []error{
+					errors.New("expected: map is not equal to any of the values"),
+				},
+			})
+			break
 		}
-	}
-
-	if isListed {
-		opChain.fail(AssertionFailure{
-			Type:     AssertNotBelongs,
-			Actual:   &AssertionValue{o.value},
-			Expected: &AssertionValue{AssertionList(values)},
-			Errors: []error{
-				errors.New("expected: map is not equal to any of the values"),
-			},
-		})
 	}
 
 	return o

--- a/object.go
+++ b/object.go
@@ -744,15 +744,19 @@ func (o *Object) Equal(value interface{}) *Object {
 	return o.IsEqual(value)
 }
 
-// InList succeeds if object is listed by given [values...].
-// Before comparison, both object and value are converted to canonical form.
+// InList succeeds if whole object is equal to one of the elements from given
+// list of objects.
+// Before comparison, each object is converted to canonical form.
 //
-// values should be an array of map[string]interface{} or struct.
+// Each value should be map[string]interface{} or struct.
 //
 // Example:
 //
 //	object := NewObject(t, map[string]interface{}{"foo": 123})
-//	object.InList(map[string]interface{}{"foo": 123})
+//	object.InList(
+//		map[string]interface{}{"foo": 123},
+//		map[string]interface{}{"bar": 456},
+//	)
 func (o *Object) InList(values ...interface{}) *Object {
 	opChain := o.chain.enter("InList()")
 	defer opChain.leave()
@@ -790,7 +794,7 @@ func (o *Object) InList(values ...interface{}) *Object {
 			Actual:   &AssertionValue{o.value},
 			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
-				errors.New("expected: map is listed"),
+				errors.New("expected: map is equal to one of the values"),
 			},
 		})
 	}
@@ -798,15 +802,19 @@ func (o *Object) InList(values ...interface{}) *Object {
 	return o
 }
 
-// NotInList succeeds if object is not listed by given [values...].
-// Before comparison, both object and value are converted to canonical form.
+// NotInList succeeds if whole object is equal to any of the elements from
+// given list of objects.
+// Before comparison, each object is converted to canonical form.
 //
-// values should be an array of map[string]interface{} or struct.
+// Each value should be map[string]interface{} or struct.
 //
 // Example:
 //
 //	object := NewObject(t, map[string]interface{}{"foo": 123})
-//	object.InList(map[string]interface{}{"bar": 456})
+//	object.NotInList(
+//		map[string]interface{}{"bar": 456},
+//		map[string]interface{}{"baz": 789},
+//	)
 func (o *Object) NotInList(values ...interface{}) *Object {
 	opChain := o.chain.enter("NotInList()")
 	defer opChain.leave()
@@ -844,7 +852,7 @@ func (o *Object) NotInList(values ...interface{}) *Object {
 			Actual:   &AssertionValue{o.value},
 			Expected: &AssertionValue{AssertionList(values)},
 			Errors: []error{
-				errors.New("expected: map is not listed"),
+				errors.New("expected: map is not equal to any of the values"),
 			},
 		})
 	}

--- a/object_test.go
+++ b/object_test.go
@@ -430,6 +430,14 @@ func TestObject_InList(t *testing.T) {
 
 	assert.Equal(t, map[string]interface{}{"foo": 123.0}, value.Raw())
 
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
 	value.InList(map[string]interface{}{})
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()

--- a/object_test.go
+++ b/object_test.go
@@ -438,27 +438,45 @@ func TestObject_InList(t *testing.T) {
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 
-	value.InList(map[string]interface{}{"FOO": 123.0}, map[string]interface{}{"BAR": 456.0})
+	value.InList(
+		map[string]interface{}{"FOO": 123.0},
+		map[string]interface{}{"BAR": 456.0},
+	)
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 
-	value.NotInList(map[string]interface{}{"FOO": 123.0}, map[string]interface{}{"BAR": 456.0})
+	value.NotInList(
+		map[string]interface{}{"FOO": 123.0},
+		map[string]interface{}{"BAR": 456.0},
+	)
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 
-	value.InList(map[string]interface{}{"foo": 456.0}, map[string]interface{}{"bar": 123.0})
+	value.InList(
+		map[string]interface{}{"foo": 456.0},
+		map[string]interface{}{"bar": 123.0},
+	)
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 
-	value.NotInList(map[string]interface{}{"foo": 456.0}, map[string]interface{}{"bar": 123.0})
+	value.NotInList(
+		map[string]interface{}{"foo": 456.0},
+		map[string]interface{}{"bar": 123.0},
+	)
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 
-	value.InList(map[string]interface{}{"foo": 123.0}, map[string]interface{}{"bar": 456.0})
+	value.InList(
+		map[string]interface{}{"foo": 123.0},
+		map[string]interface{}{"bar": 456.0},
+	)
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()
 
-	value.NotInList(map[string]interface{}{"foo": 123.0}, map[string]interface{}{"bar": 456.0})
+	value.NotInList(
+		map[string]interface{}{"foo": 123.0},
+		map[string]interface{}{"bar": 456.0},
+	)
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 

--- a/object_test.go
+++ b/object_test.go
@@ -26,6 +26,8 @@ func TestObject_Failed(t *testing.T) {
 		value.NotEmpty()
 		value.IsEqual(nil)
 		value.NotEqual(nil)
+		value.InList(nil)
+		value.NotInList(nil)
 		value.ContainsKey("foo")
 		value.NotContainsKey("foo")
 		value.ContainsValue("foo")
@@ -417,6 +419,66 @@ func TestObject_Equal(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.NotEqual(nil)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+}
+
+func TestObject_InList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewObject(reporter, map[string]interface{}{"foo": 123.0})
+
+	assert.Equal(t, map[string]interface{}{"foo": 123.0}, value.Raw())
+
+	value.InList(map[string]interface{}{})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(map[string]interface{}{})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(map[string]interface{}{"FOO": 123.0}, map[string]interface{}{"BAR": 456.0})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(map[string]interface{}{"FOO": 123.0}, map[string]interface{}{"BAR": 456.0})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(map[string]interface{}{"foo": 456.0}, map[string]interface{}{"bar": 123.0})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(map[string]interface{}{"foo": 456.0}, map[string]interface{}{"bar": 123.0})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(map[string]interface{}{"foo": 123.0}, map[string]interface{}{"bar": 456.0})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(map[string]interface{}{"foo": 123.0}, map[string]interface{}{"bar": 456.0})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(struct {
+		Foo float64 `json:"foo"`
+	}{Foo: 123.00})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(struct {
+		Foo float64 `json:"foo"`
+	}{Foo: 123.00})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList(nil)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList(nil)
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 }

--- a/string.go
+++ b/string.go
@@ -245,6 +245,70 @@ func (s *String) Equal(value string) *String {
 	return s.IsEqual(value)
 }
 
+// InList succeeds if string is listed by given [values...].
+//
+// Example:
+//
+//	str := NewString(t, "Hello")
+//	str.InList("Hello", "Goodbye")
+func (s *String) InList(values ...string) *String {
+	opChain := s.chain.enter("InList()")
+	defer opChain.leave()
+
+	if opChain.failed() {
+		return s
+	}
+
+	for _, v := range values {
+		if s.value == v {
+			return s
+		}
+	}
+
+	opChain.fail(AssertionFailure{
+		Type:     AssertBelongs,
+		Actual:   &AssertionValue{s.value},
+		Expected: &AssertionValue{AssertionList(stringList(values))},
+		Errors: []error{
+			errors.New("expected: string is listed"),
+		},
+	})
+
+	return s
+}
+
+// NotInList succeeds if string is not listed by given [values...].
+//
+// Example:
+//
+//	str := NewString(t, "Hello")
+//	str.NotInList("NotInList", "Goodbye")
+func (s *String) NotInList(values ...string) *String {
+	opChain := s.chain.enter("NotInList()")
+	defer opChain.leave()
+
+	if opChain.failed() {
+		return s
+	}
+
+	for _, v := range values {
+		if s.value == v {
+			opChain.fail(AssertionFailure{
+				Type:     AssertNotBelongs,
+				Actual:   &AssertionValue{s.value},
+				Expected: &AssertionValue{AssertionList(stringList(values))},
+				Errors: []error{
+					errors.New("expected: string is not listed"),
+				},
+			})
+
+			return s
+		}
+	}
+
+	return s
+}
+
 // IsEqualFold succeeds if string is equal to given Go string after applying Unicode
 // case-folding (so it's a case-insensitive match).
 //
@@ -1141,4 +1205,13 @@ func (s *String) Number() *Number {
 // Deprecated: use AsDateTime instead.
 func (s *String) DateTime(layout ...string) *DateTime {
 	return s.AsDateTime(layout...)
+}
+
+func stringList(values []string) []interface{} {
+	s := make([]interface{}, 0, len(values))
+	for _, v := range values {
+		s = append(s, v)
+	}
+
+	return s
 }

--- a/string.go
+++ b/string.go
@@ -271,20 +271,23 @@ func (s *String) InList(values ...string) *String {
 		return s
 	}
 
+	var isListed bool
 	for _, v := range values {
 		if s.value == v {
-			return s
+			isListed = true
 		}
 	}
 
-	opChain.fail(AssertionFailure{
-		Type:     AssertBelongs,
-		Actual:   &AssertionValue{s.value},
-		Expected: &AssertionValue{AssertionList(stringList(values))},
-		Errors: []error{
-			errors.New("expected: string is equal to one of the values"),
-		},
-	})
+	if !isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertBelongs,
+			Actual:   &AssertionValue{s.value},
+			Expected: &AssertionValue{AssertionList(stringList(values))},
+			Errors: []error{
+				errors.New("expected: string is equal to one of the values"),
+			},
+		})
+	}
 
 	return s
 }
@@ -325,8 +328,7 @@ func (s *String) NotInList(values ...string) *String {
 					errors.New("expected: string is not equal to any of the values"),
 				},
 			})
-
-			return s
+			break
 		}
 	}
 

--- a/string.go
+++ b/string.go
@@ -245,7 +245,8 @@ func (s *String) Equal(value string) *String {
 	return s.IsEqual(value)
 }
 
-// InList succeeds if string is listed by given [values...].
+// InList succeeds if string is equal to one of the elements from given
+// list of strings.
 //
 // Example:
 //
@@ -281,14 +282,15 @@ func (s *String) InList(values ...string) *String {
 		Actual:   &AssertionValue{s.value},
 		Expected: &AssertionValue{AssertionList(stringList(values))},
 		Errors: []error{
-			errors.New("expected: string is listed"),
+			errors.New("expected: string is equal to one of the values"),
 		},
 	})
 
 	return s
 }
 
-// NotInList succeeds if string is not listed by given [values...].
+// NotInList succeeds if string is not equal to any of the elements from
+// given list of strings.
 //
 // Example:
 //
@@ -320,7 +322,7 @@ func (s *String) NotInList(values ...string) *String {
 				Actual:   &AssertionValue{s.value},
 				Expected: &AssertionValue{AssertionList(stringList(values))},
 				Errors: []error{
-					errors.New("expected: string is not listed"),
+					errors.New("expected: string is not equal to any of the values"),
 				},
 			})
 

--- a/string.go
+++ b/string.go
@@ -259,6 +259,17 @@ func (s *String) InList(values ...string) *String {
 		return s
 	}
 
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return s
+	}
+
 	for _, v := range values {
 		if s.value == v {
 			return s
@@ -288,6 +299,17 @@ func (s *String) NotInList(values ...string) *String {
 	defer opChain.leave()
 
 	if opChain.failed() {
+		return s
+	}
+
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return s
 	}
 

--- a/string_test.go
+++ b/string_test.go
@@ -227,6 +227,14 @@ func TestString_List(t *testing.T) {
 
 	assert.Equal(t, "foo", value.Raw())
 
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.InList()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
 	value.InList("foo", "bar")
 	value.chain.assertNotFailed(t)
 	value.chain.clearFailed()

--- a/string_test.go
+++ b/string_test.go
@@ -29,6 +29,8 @@ func TestString_Failed(t *testing.T) {
 	value.NotEmpty()
 	value.IsEqual("")
 	value.NotEqual("")
+	value.InList("")
+	value.NotInList("")
 	value.IsEqualFold("")
 	value.NotEqualFold("")
 	value.Contains("")
@@ -214,6 +216,30 @@ func TestString_Equal(t *testing.T) {
 	value.chain.clearFailed()
 
 	value.NotEqual("foo")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+}
+
+func TestString_List(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewString(reporter, "foo")
+
+	assert.Equal(t, "foo", value.Raw())
+
+	value.InList("foo", "bar")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.InList("FOO", "BAR")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList("FOO", "bar")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotInList("foo", "BAR")
 	value.chain.assertFailed(t)
 	value.chain.clearFailed()
 }

--- a/value.go
+++ b/value.go
@@ -551,6 +551,7 @@ func (v *Value) InList(values ...interface{}) *Value {
 		return v
 	}
 
+	var isListed bool
 	for _, val := range values {
 		expected, ok := canonValue(opChain, val)
 		if !ok {
@@ -558,18 +559,21 @@ func (v *Value) InList(values ...interface{}) *Value {
 		}
 
 		if reflect.DeepEqual(expected, v.value) {
-			return v
+			isListed = true
+			break
 		}
 	}
 
-	opChain.fail(AssertionFailure{
-		Type:     AssertBelongs,
-		Actual:   &AssertionValue{v.value},
-		Expected: &AssertionValue{AssertionList(values)},
-		Errors: []error{
-			errors.New("expected: value is equal to one of the values"),
-		},
-	})
+	if !isListed {
+		opChain.fail(AssertionFailure{
+			Type:     AssertBelongs,
+			Actual:   &AssertionValue{v.value},
+			Expected: &AssertionValue{AssertionList(values)},
+			Errors: []error{
+				errors.New("expected: value is equal to one of the values"),
+			},
+		})
+	}
 
 	return v
 }
@@ -616,6 +620,7 @@ func (v *Value) NotInList(values ...interface{}) *Value {
 					errors.New("expected: value is not equal to any of the values"),
 				},
 			})
+			break
 		}
 	}
 

--- a/value.go
+++ b/value.go
@@ -540,6 +540,17 @@ func (v *Value) InList(values ...interface{}) *Value {
 		return v
 	}
 
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
+		return v
+	}
+
 	for _, val := range values {
 		expected, ok := canonValue(opChain, val)
 		if !ok {
@@ -576,6 +587,17 @@ func (v *Value) NotInList(values ...interface{}) *Value {
 	defer opChain.leave()
 
 	if opChain.failed() {
+		return v
+	}
+
+	if len(values) == 0 {
+		opChain.fail(AssertionFailure{
+			Type: AssertUsage,
+			Errors: []error{
+				errors.New("unexpected empty list argument"),
+			},
+		})
+
 		return v
 	}
 

--- a/value.go
+++ b/value.go
@@ -524,9 +524,9 @@ func (v *Value) Equal(value interface{}) *Value {
 	return v.IsEqual(value)
 }
 
-// InList succeeds if value is listed by given [values....]
-// (e.g. map, slice, string, etc).
-// Before comparison, both values are converted to canonical form.
+// InList succeeds if whole value is equal to one of the elements from given
+// list of values (e.g. map, slice, string, etc).
+// Before comparison, each value are converted to canonical form.
 //
 // Example:
 //
@@ -567,16 +567,16 @@ func (v *Value) InList(values ...interface{}) *Value {
 		Actual:   &AssertionValue{v.value},
 		Expected: &AssertionValue{AssertionList(values)},
 		Errors: []error{
-			errors.New("expected: value is listed"),
+			errors.New("expected: value is equal to one of the values"),
 		},
 	})
 
 	return v
 }
 
-// NotInList succeeds if value is not listed by given [values....]
-// (e.g. map, slice, string, etc).
-// Before comparison, both values are converted to canonical form.
+// NotInList succeeds if whole value is not equal to any of the elements from
+// given list of values (e.g. map, slice, string, etc).
+// Before comparison, each value are converted to canonical form.
 //
 // Example:
 //
@@ -613,7 +613,7 @@ func (v *Value) NotInList(values ...interface{}) *Value {
 				Actual:   &AssertionValue{v.value},
 				Expected: &AssertionValue{AssertionList(values)},
 				Errors: []error{
-					errors.New("expected: value is not listed"),
+					errors.New("expected: value is not equal to any of the values"),
 				},
 			})
 		}

--- a/value_test.go
+++ b/value_test.go
@@ -420,6 +420,9 @@ func TestValue_InList(t *testing.T) {
 		Data: []int{1, 2, 3, 4},
 	}
 
+	NewValue(reporter, data1).InList().chain.assertFailed(t)
+	NewValue(reporter, data2).NotInList().chain.assertFailed(t)
+
 	NewValue(reporter, data1).InList(data1, data3).chain.assertNotFailed(t)
 	NewValue(reporter, data2).NotInList(data1, data3).chain.assertNotFailed(t)
 

--- a/value_test.go
+++ b/value_test.go
@@ -42,6 +42,9 @@ func TestValue_Failed(t *testing.T) {
 
 	value.IsEqual(nil)
 	value.NotEqual(nil)
+
+	value.InList(nil)
+	value.NotInList(nil)
 }
 
 func TestValue_Constructors(t *testing.T) {
@@ -404,6 +407,36 @@ func TestValue_Equal(t *testing.T) {
 
 	NewValue(reporter, data1).IsEqual(func() {}).chain.assertFailed(t)
 	NewValue(reporter, data1).NotEqual(func() {}).chain.assertFailed(t)
+}
+
+func TestValue_InList(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	data1 := map[string]interface{}{"foo": "bar"}
+	data2 := "baz"
+	data3 := struct {
+		Data []int `json:"data"`
+	}{
+		Data: []int{1, 2, 3, 4},
+	}
+
+	NewValue(reporter, data1).InList(data1, data3).chain.assertNotFailed(t)
+	NewValue(reporter, data2).NotInList(data1, data3).chain.assertNotFailed(t)
+
+	NewValue(reporter, data1).InList(data2, data3).chain.assertFailed(t)
+	NewValue(reporter, data2).NotInList(data2, data3).chain.assertFailed(t)
+
+	NewValue(reporter, data1).InList(data2).chain.assertFailed(t)
+	NewValue(reporter, data2).NotInList(data2).chain.assertFailed(t)
+
+	NewValue(reporter, data1).InList(data1).chain.assertNotFailed(t)
+	NewValue(reporter, data2).NotInList(data1).chain.assertNotFailed(t)
+
+	NewValue(reporter, nil).InList(map[string]interface{}(nil)).chain.assertNotFailed(t)
+	NewValue(reporter, nil).NotInList(map[string]interface{}{}).chain.assertNotFailed(t)
+
+	NewValue(reporter, data1).InList(func() {}).chain.assertFailed(t)
+	NewValue(reporter, data1).NotInList(func() {}).chain.assertFailed(t)
 }
 
 func TestValue_PathObject(t *testing.T) {


### PR DESCRIPTION
This PR does the following:
- Add `InList` and `NotInList` for given types:
  - [x] Value
  - [x] Object
  - [x] Array
  - [x] String
  - [x] Number
  - [x] Boolean (just for completeness)
  - [x] Duration
  - [x] DateTime
-Since `AssertionList` rejects a single slice as a param, single array param in `InList` will behave like `IsEqual` and `NotInList` will behave like `NotEqual`. Addressed in commit https://github.com/gavv/httpexpect/commit/649ee8caf0e8c918aa9a2de8a8d6f6c5c3ec1cf7

https://github.com/gavv/httpexpect/blob/86f366a2d10b8a8ddd3cb1a9b2a5c00f37a1df68/assertion_validation.go#L186-L190

For issue https://github.com/gavv/httpexpect/issues/250