### PR TITLE
feat: add unit tests for array contains all and not contains all

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -855,6 +855,112 @@ func TestArray_Contains(t *testing.T) {
 	})
 }
 
+func TestArray_ContainsAll(t *testing.T) {
+	reporter := newMockReporter(t)
+
+	value := NewArray(reporter, []interface{}{123, "foo"})
+
+	value.ContainsAll(123)
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll(123)
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.ContainsAll("foo")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll("foo")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.ContainsAll("FOO")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll("FOO")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.ContainsAll(123, "foo")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll(123, "foo")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.ContainsAll("foo", "foo")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll("foo", "foo")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.ContainsAll(123, "foo", "FOO")
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll(123, "foo", "FOO")
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	value.ContainsAll([]interface{}{123, "foo"})
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
+
+	value.NotContainsAll([]interface{}{123, "foo"})
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myInt int
+		)
+
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{123, 456})
+
+		assert.Equal(t, []interface{}{123.0, 456.0}, value.Raw())
+
+		value.ContainsAll(myInt(123), 456.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAll(myInt(123), 456.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAll("123")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAll("123")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAll("123.0", "456.0")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAll("123.0", "456.0")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAll(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAll(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+}
+
 func TestArray_ContainsAny(t *testing.T) {
 	reporter := newMockReporter(t)
 


### PR DESCRIPTION
# Description

Introducing unit tests for Array.ContainsAll and Array.NotContainsAll. This resolves [issue #237](https://github.com/gavv/httpexpect/issues/237).