### PR TITLE
Canonization tests for arrays

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -1334,6 +1334,54 @@ func TestArray_ContainsOnly(t *testing.T) {
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 	})
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myInt int
+		)
+
+		value := NewArray(reporter, []interface{}{123, 456, 456})
+
+		value.ContainsOnly(456.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsOnly(456.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsOnly(myInt(123), 456.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsOnly(myInt(123), 456.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsOnly(123.0, 456.0, 456.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsOnly(123.0, 456.0, 456.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsOnly(myInt(123), myInt(456), 456.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsOnly(myInt(123), 456.0, myInt(456))
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsOnly(myInt(123), "456", 456.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsOnly(myInt(123), 456.0, "456")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+	})
 }
 
 func TestArray_IsValueEqual(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -485,18 +485,6 @@ func TestArray_IsEqual(t *testing.T) {
 		value3.chain.clearFailed()
 	})
 
-	t.Run("nil check", func(t *testing.T) {
-		value := NewArray(reporter, []interface{}{123, 456})
-
-		value.IsEqual(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqual(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-	})
-
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myArray []interface{}
@@ -522,7 +510,26 @@ func TestArray_IsEqual(t *testing.T) {
 		value.NotEqual([]interface{}{"123", "456"})
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
+	})
 
+	t.Run("invalid argument", func(t *testing.T) {
+		value := NewArray(reporter, []interface{}{})
+
+		value.IsEqual(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqual(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 	})
 }
 
@@ -611,19 +618,6 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
-	t.Run("nil check", func(t *testing.T) {
-
-		value := NewArray(reporter, []interface{}{123, 456, "foo"})
-
-		value.IsEqualUnordered(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqualUnordered(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-	})
-
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myArray []interface{}
@@ -658,6 +652,28 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 
 		value.NotEqualUnordered(myArray{"123.0", "456.0", "foo"})
 		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+	})
+
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{})
+
+		value.IsEqualUnordered(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(func() {})
+		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 	})
 }
@@ -735,22 +751,6 @@ func TestArray_InList(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
-	t.Run("invalid arguments", func(t *testing.T) {
-
-		array := NewArray(reporter, []interface{}{
-			123,
-			456,
-		})
-
-		array.InList(func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-
-		array.NotInList(func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-	})
-
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myArray []interface{}
@@ -814,14 +814,35 @@ func TestArray_InList(t *testing.T) {
 		array.NotInList(myArray{"123.0", "456.0", myArray{"789.0", "567.0"}, myMap{"a": "b"}})
 		array.chain.assertNotFailed(t)
 		array.chain.clearFailed()
+	})
 
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		array := NewArray(reporter, []interface{}{})
+
+		array.InList(nil)
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(nil)
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.InList(func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
 	})
 }
 
 func TestArray_ConsistsOf(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("basic", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
 		value.ConsistsOf(123)
@@ -865,22 +886,12 @@ func TestArray_ConsistsOf(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
-	t.Run("invalid arguments", func(t *testing.T) {
-		value := NewArray(reporter, []interface{}{123, 456})
-
-		value.ConsistsOf(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotConsistsOf(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-	})
-
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myInt int
 		)
+
+		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, 456})
 
@@ -893,14 +904,26 @@ func TestArray_ConsistsOf(t *testing.T) {
 		value.NotConsistsOf(myInt(123), 456.0)
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
+	})
 
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{})
+
+		value.ConsistsOf(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotConsistsOf(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 	})
 }
 
 func TestArray_Contains(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("basic", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
@@ -949,34 +972,12 @@ func TestArray_Contains(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
-	t.Run("invalid arguments", func(t *testing.T) {
-		value := NewArray(reporter, []interface{}{123, 456})
-
-		value.Contains(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotContains(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.ContainsOnly(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.ContainsAny(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotContainsAny(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-	})
-
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myInt int
 		)
+
+		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, 456})
 
@@ -1005,6 +1006,20 @@ func TestArray_Contains(t *testing.T) {
 		value.NotContains("123")
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
+
+		value.Contains(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContains(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{})
 
 		value.Contains(func() {})
 		value.chain.assertFailed(t)
@@ -1118,7 +1133,7 @@ func TestArray_ContainsAll(t *testing.T) {
 	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewArray(reporter, []interface{}{123, 456})
+		value := NewArray(reporter, []interface{}{})
 
 		value.ContainsAll(func() {})
 		value.chain.assertFailed(t)
@@ -1242,7 +1257,20 @@ func TestArray_ContainsAny(t *testing.T) {
 		value.NotContainsAny(myArray{"567", 456.0})
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
+	})
 
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{})
+
+		value.ContainsAny(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 	})
 }
 
@@ -1372,12 +1400,25 @@ func TestArray_ContainsOnly(t *testing.T) {
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
 	})
+
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{})
+
+		value.ContainsOnly(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsOnly(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
 }
 
 func TestArray_IsValueEqual(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("basic", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
 		array := NewArray(reporter, []interface{}{
 			123,
@@ -1420,22 +1461,8 @@ func TestArray_IsValueEqual(t *testing.T) {
 		array.chain.clearFailed()
 	})
 
-	t.Run("invalid arguments", func(t *testing.T) {
-		array := NewArray(reporter, []interface{}{
-			123,
-			[]interface{}{"456", 789},
-		})
-
-		array.IsValueEqual(1, func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-
-		array.NotValueEqual(1, func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-	})
-
 	t.Run("struct", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
 		array := NewArray(reporter, []interface{}{
 			map[string]interface{}{
@@ -1488,6 +1515,8 @@ func TestArray_IsValueEqual(t *testing.T) {
 			myInt   int
 		)
 
+		reporter := newMockReporter(t)
+
 		array := NewArray(reporter, []interface{}{
 			123,
 			[]interface{}{"456", 789},
@@ -1514,6 +1543,7 @@ func TestArray_IsValueEqual(t *testing.T) {
 	})
 
 	t.Run("invalid index", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
 		array := NewArray(reporter, []interface{}{1, 2, 3})
 
@@ -1522,6 +1552,20 @@ func TestArray_IsValueEqual(t *testing.T) {
 		array.chain.clearFailed()
 
 		array.NotValueEqual(-1, 999)
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+	})
+
+	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		array := NewArray(reporter, []interface{}{1, 2, 3})
+
+		array.IsValueEqual(1, func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotValueEqual(1, func() {})
 		array.chain.assertFailed(t)
 		array.chain.clearFailed()
 	})
@@ -1844,7 +1888,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertNotFailed(t)
 	})
 
-	t.Run("invalid arguments", func(ts *testing.T) {
+	t.Run("invalid argument", func(ts *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -1994,7 +2038,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid arguments", func(ts *testing.T) {
+	t.Run("invalid argument", func(ts *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -2078,7 +2122,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertFailed(t)
 	})
 
-	t.Run("invalid arguments", func(ts *testing.T) {
+	t.Run("invalid argument", func(ts *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 

--- a/array_test.go
+++ b/array_test.go
@@ -791,11 +791,27 @@ func TestArray_InList(t *testing.T) {
 			map[string]interface{}{"a": "b"},
 		})
 
-		array.InList(myArray{myInt(123.0), myInt(456.0), myArray{myInt(789.0), myInt(567.0)}, myMap{"a": "b"}})
+		array.InList(myArray{
+			myInt(123.0), 
+			myInt(456.0), 
+			myArray{
+				myInt(789.0), 
+				myInt(567.0),
+			}, 
+			myMap{"a": "b"},
+		})
 		array.chain.assertNotFailed(t)
 		array.chain.clearFailed()
 
-		array.NotInList(myArray{myInt(123.0), myInt(456.0), myArray{myInt(789.0), myInt(567.0)}, myMap{"a": "b"}})
+		array.NotInList(myArray{
+			myInt(123.0), 
+			myInt(456.0), 
+			myArray{
+				myInt(789.0), 
+				myInt(567.0),
+			}, 
+			myMap{"a": "b"},
+		})
 		array.chain.assertFailed(t)
 		array.chain.clearFailed()
 

--- a/array_test.go
+++ b/array_test.go
@@ -792,24 +792,24 @@ func TestArray_InList(t *testing.T) {
 		})
 
 		array.InList(myArray{
-			myInt(123.0), 
-			myInt(456.0), 
+			myInt(123.0),
+			myInt(456.0),
 			myArray{
-				myInt(789.0), 
+				myInt(789.0),
 				myInt(567.0),
-			}, 
+			},
 			myMap{"a": "b"},
 		})
 		array.chain.assertNotFailed(t)
 		array.chain.clearFailed()
 
 		array.NotInList(myArray{
-			myInt(123.0), 
-			myInt(456.0), 
+			myInt(123.0),
+			myInt(456.0),
 			myArray{
-				myInt(789.0), 
+				myInt(789.0),
 				myInt(567.0),
-			}, 
+			},
 			myMap{"a": "b"},
 		})
 		array.chain.assertFailed(t)

--- a/array_test.go
+++ b/array_test.go
@@ -528,9 +528,9 @@ func TestArray_IsEqual(t *testing.T) {
 }
 
 func TestArray_IsEqualUnordered(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("without duplicates", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
 		value.IsEqualUnordered([]interface{}{123})
@@ -575,6 +575,8 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 	})
 
 	t.Run("with duplicates", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, "foo", "foo"})
 
 		value.IsEqualUnordered([]interface{}{123, "foo"})
@@ -616,8 +618,9 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 			myInt   int
 		)
 
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, 456, "foo"})
-		duplicateValue := NewArray(reporter, []interface{}{123, 123, "foo"})
 
 		assert.Equal(t, []interface{}{123.0, 456.0, "foo"}, value.Raw())
 
@@ -626,14 +629,6 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.chain.clearFailed()
 
 		value.NotEqualUnordered(myArray{myInt(456), 123.0, "foo"})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.IsEqualUnordered(myArray{456.0, myInt(123.0), "foo"})
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqualUnordered(myArray{456.0, myInt(123.0), "foo"})
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 
@@ -660,54 +655,13 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.NotEqualUnordered(nil)
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
-
-		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo"})
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.NotEqualUnordered(myArray{myInt(123), "foo"})
-		duplicateValue.chain.assertNotFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo", 123.0})
-		duplicateValue.chain.assertNotFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.NotEqualUnordered(myArray{123.0, "foo", myInt(123)})
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.IsEqualUnordered(myArray{"123", "123", "foo"})
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.NotEqualUnordered(myArray{"123", "123", "foo"})
-		duplicateValue.chain.assertNotFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.IsEqualUnordered(myArray{"123.0", "123.0", "foo"})
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.NotEqualUnordered(myArray{"123.0", "123.0", "foo"})
-		duplicateValue.chain.assertNotFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.IsEqualUnordered(nil)
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.NotEqualUnordered(nil)
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
 	})
 }
 
 func TestArray_InList(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("basic", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{"foo", "bar"})
 
 		assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
@@ -784,6 +738,8 @@ func TestArray_InList(t *testing.T) {
 			myInt   int
 		)
 
+		reporter := newMockReporter(t)
+
 		array := NewArray(reporter, []interface{}{
 			123,
 			456,
@@ -847,7 +803,6 @@ func TestArray_InList(t *testing.T) {
 		array.chain.assertFailed(t)
 		array.chain.clearFailed()
 	})
-
 }
 
 func TestArray_ConsistsOf(t *testing.T) {
@@ -1138,9 +1093,9 @@ func TestArray_ContainsAll(t *testing.T) {
 }
 
 func TestArray_ContainsAny(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("basic", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
 		value.ContainsAny(123)
@@ -1198,6 +1153,8 @@ func TestArray_ContainsAny(t *testing.T) {
 			myArray []interface{}
 		)
 
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, 789, "foo", []interface{}{567, 456}})
 
 		value.ContainsAny(myInt(123), 789.0)
@@ -1249,13 +1206,12 @@ func TestArray_ContainsAny(t *testing.T) {
 		value.chain.clearFailed()
 
 	})
-
 }
 
 func TestArray_ContainsOnly(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("without duplicates", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
 		value.ContainsOnly(123)
@@ -1300,6 +1256,8 @@ func TestArray_ContainsOnly(t *testing.T) {
 	})
 
 	t.Run("with duplicates", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, "foo", "foo"})
 
 		value.ContainsOnly(123, "foo")
@@ -1340,6 +1298,8 @@ func TestArray_ContainsOnly(t *testing.T) {
 			myInt int
 		)
 
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, 456, 456})
 
 		value.ContainsOnly(456.0)
@@ -1363,14 +1323,6 @@ func TestArray_ContainsOnly(t *testing.T) {
 		value.chain.clearFailed()
 
 		value.NotContainsOnly(123.0, 456.0, 456.0)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.ContainsOnly(myInt(123), myInt(456), 456.0)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotContainsOnly(myInt(123), 456.0, myInt(456))
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 
@@ -1610,7 +1562,7 @@ func TestArray_Every(t *testing.T) {
 
 func TestArray_Transform(t *testing.T) {
 	t.Run("check index", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, 3})
 
 		newArray := array.Transform(func(idx int, val interface{}) interface{} {
@@ -1625,7 +1577,7 @@ func TestArray_Transform(t *testing.T) {
 	})
 
 	t.Run("transform value", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{2, 4, 6})
 
 		newArray := array.Transform(func(_ int, val interface{}) interface{} {
@@ -1641,7 +1593,7 @@ func TestArray_Transform(t *testing.T) {
 	})
 
 	t.Run("empty array", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
 		newArray := array.Transform(func(_ int, _ interface{}) interface{} {
@@ -1653,13 +1605,14 @@ func TestArray_Transform(t *testing.T) {
 	})
 
 	t.Run("invalid argument", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{2, 4, 6})
 
 		newArray := array.Transform(nil)
 
 		newArray.chain.assertFailed(t)
 	})
+
 }
 
 func TestArray_Filter(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -358,9 +358,9 @@ func TestArray_IsEmpty(t *testing.T) {
 }
 
 func TestArray_IsEqual(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("empty", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{})
 
 		assert.Equal(t, []interface{}{}, value.Raw())
@@ -383,6 +383,8 @@ func TestArray_IsEqual(t *testing.T) {
 	})
 
 	t.Run("not empty", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{"foo", "bar"})
 
 		assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
@@ -421,6 +423,8 @@ func TestArray_IsEqual(t *testing.T) {
 	})
 
 	t.Run("types", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value1 := NewArray(reporter, []interface{}{"foo", "bar"})
 		value2 := NewArray(reporter, []interface{}{123, 456})
 		value3 := NewArray(reporter, []interface{}{
@@ -491,6 +495,8 @@ func TestArray_IsEqual(t *testing.T) {
 			myInt   int
 		)
 
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{123, 456})
 
 		assert.Equal(t, []interface{}{123.0, 456.0}, value.Raw())
@@ -513,6 +519,8 @@ func TestArray_IsEqual(t *testing.T) {
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
 		value := NewArray(reporter, []interface{}{})
 
 		value.IsEqual(nil)

--- a/array_test.go
+++ b/array_test.go
@@ -358,9 +358,9 @@ func TestArray_IsEmpty(t *testing.T) {
 }
 
 func TestArray_IsEqual(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		reporter := newMockReporter(t)
+	reporter := newMockReporter(t)
 
+	t.Run("empty", func(t *testing.T) {
 		value := NewArray(reporter, []interface{}{})
 
 		assert.Equal(t, []interface{}{}, value.Raw())
@@ -383,8 +383,6 @@ func TestArray_IsEqual(t *testing.T) {
 	})
 
 	t.Run("not empty", func(t *testing.T) {
-		reporter := newMockReporter(t)
-
 		value := NewArray(reporter, []interface{}{"foo", "bar"})
 
 		assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
@@ -423,8 +421,6 @@ func TestArray_IsEqual(t *testing.T) {
 	})
 
 	t.Run("types", func(t *testing.T) {
-		reporter := newMockReporter(t)
-
 		value1 := NewArray(reporter, []interface{}{"foo", "bar"})
 		value2 := NewArray(reporter, []interface{}{123, 456})
 		value3 := NewArray(reporter, []interface{}{
@@ -489,13 +485,23 @@ func TestArray_IsEqual(t *testing.T) {
 		value3.chain.clearFailed()
 	})
 
+	t.Run("nil check", func(t *testing.T) {
+		value := NewArray(reporter, []interface{}{123, 456})
+
+		value.IsEqual(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myArray []interface{}
 			myInt   int
 		)
-
-		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, 456})
 
@@ -517,13 +523,6 @@ func TestArray_IsEqual(t *testing.T) {
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
 
-		value.IsEqual(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqual(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
 	})
 }
 
@@ -612,6 +611,19 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
+	t.Run("nil check", func(t *testing.T) {
+
+		value := NewArray(reporter, []interface{}{123, 456, "foo"})
+
+		value.IsEqualUnordered(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myArray []interface{}
@@ -646,14 +658,6 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 
 		value.NotEqualUnordered(myArray{"123.0", "456.0", "foo"})
 		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.IsEqualUnordered(nil)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqualUnordered(nil)
-		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 	})
 }
@@ -731,6 +735,22 @@ func TestArray_InList(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
+	t.Run("invalid arguments", func(t *testing.T) {
+
+		array := NewArray(reporter, []interface{}{
+			123,
+			456,
+		})
+
+		array.InList(func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+	})
+
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myArray []interface{}
@@ -795,20 +815,13 @@ func TestArray_InList(t *testing.T) {
 		array.chain.assertNotFailed(t)
 		array.chain.clearFailed()
 
-		array.InList(func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-
-		array.NotInList(func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
 	})
 }
 
 func TestArray_ConsistsOf(t *testing.T) {
-	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
+	reporter := newMockReporter(t)
 
+	t.Run("basic", func(t *testing.T) {
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
 		value.ConsistsOf(123)
@@ -852,12 +865,22 @@ func TestArray_ConsistsOf(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
+	t.Run("invalid arguments", func(t *testing.T) {
+		value := NewArray(reporter, []interface{}{123, 456})
+
+		value.ConsistsOf(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotConsistsOf(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myInt int
 		)
-
-		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, 456})
 
@@ -871,19 +894,13 @@ func TestArray_ConsistsOf(t *testing.T) {
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 
-		value.ConsistsOf(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotConsistsOf(func() {})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
 	})
 }
 
 func TestArray_Contains(t *testing.T) {
+	reporter := newMockReporter(t)
+
 	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, "foo"})
 
@@ -932,12 +949,34 @@ func TestArray_Contains(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
+	t.Run("invalid arguments", func(t *testing.T) {
+		value := NewArray(reporter, []interface{}{123, 456})
+
+		value.Contains(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContains(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsOnly(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAny(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(func() {})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+
 	t.Run("canonization", func(t *testing.T) {
 		type (
 			myInt int
 		)
-
-		reporter := newMockReporter(t)
 
 		value := NewArray(reporter, []interface{}{123, 456})
 
@@ -1074,7 +1113,6 @@ func TestArray_ContainsAll(t *testing.T) {
 		value.NotContainsAll("123.0", "456.0")
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
-
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
@@ -1337,8 +1375,9 @@ func TestArray_ContainsOnly(t *testing.T) {
 }
 
 func TestArray_IsValueEqual(t *testing.T) {
+	reporter := newMockReporter(t)
+
 	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
 
 		array := NewArray(reporter, []interface{}{
 			123,
@@ -1372,14 +1411,6 @@ func TestArray_IsValueEqual(t *testing.T) {
 		array.chain.assertFailed(t)
 		array.chain.clearFailed()
 
-		array.IsValueEqual(2, func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-
-		array.NotValueEqual(2, func() {})
-		array.chain.assertFailed(t)
-		array.chain.clearFailed()
-
 		array.IsValueEqual(3, 777)
 		array.chain.assertFailed(t)
 		array.chain.clearFailed()
@@ -1389,8 +1420,22 @@ func TestArray_IsValueEqual(t *testing.T) {
 		array.chain.clearFailed()
 	})
 
+	t.Run("invalid arguments", func(t *testing.T) {
+		array := NewArray(reporter, []interface{}{
+			123,
+			[]interface{}{"456", 789},
+		})
+
+		array.IsValueEqual(1, func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotValueEqual(1, func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+	})
+
 	t.Run("struct", func(t *testing.T) {
-		reporter := newMockReporter(t)
 
 		array := NewArray(reporter, []interface{}{
 			map[string]interface{}{
@@ -1443,8 +1488,6 @@ func TestArray_IsValueEqual(t *testing.T) {
 			myInt   int
 		)
 
-		reporter := newMockReporter(t)
-
 		array := NewArray(reporter, []interface{}{
 			123,
 			[]interface{}{"456", 789},
@@ -1471,7 +1514,6 @@ func TestArray_IsValueEqual(t *testing.T) {
 	})
 
 	t.Run("invalid index", func(t *testing.T) {
-		reporter := newMockReporter(t)
 
 		array := NewArray(reporter, []interface{}{1, 2, 3})
 
@@ -1612,7 +1654,6 @@ func TestArray_Transform(t *testing.T) {
 
 		newArray.chain.assertFailed(t)
 	})
-
 }
 
 func TestArray_Filter(t *testing.T) {
@@ -1803,7 +1844,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertNotFailed(t)
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid arguments", func(ts *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -1953,7 +1994,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid arguments", func(ts *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -2037,7 +2078,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertFailed(t)
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid arguments", func(ts *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 

--- a/array_test.go
+++ b/array_test.go
@@ -707,73 +707,131 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 func TestArray_InList(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	value := NewArray(reporter, []interface{}{"foo", "bar"})
+	t.Run("basic", func(t *testing.T) {
+		value := NewArray(reporter, []interface{}{"foo", "bar"})
 
-	assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
+		assert.Equal(t, []interface{}{"foo", "bar"}, value.Raw())
 
-	value.InList()
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList()
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList()
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotInList()
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.InList("foo", "bar")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList("foo", "bar")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList("foo", "bar")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotInList("foo", "bar")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.InList([]interface{}{})
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList([]interface{}{})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList([]interface{}{})
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.NotInList([]interface{}{})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.InList([]interface{}{"bar", "foo"})
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList([]interface{}{"bar", "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList([]interface{}{"bar", "foo"})
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.NotInList([]interface{}{"bar", "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.InList([]interface{}{"bar", "foo"}, []interface{}{"foo", "bar"})
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.InList([]interface{}{"bar", "foo"}, []interface{}{"foo", "bar"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"foo", "bar"})
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"foo", "bar"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.InList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.NotInList([]interface{}{"bar", "foo"}, []interface{}{"FOO", "BAR"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.InList([]interface{}{"bar", "foo"}, "NOT ARRAY")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList([]interface{}{"bar", "foo"}, "NOT ARRAY")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList([]interface{}{"bar", "foo"}, "NOT ARRAY")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotInList([]interface{}{"bar", "foo"}, "NOT ARRAY")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.InList([]interface{}{"foo", "bar"}, "NOT ARRAY")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.InList([]interface{}{"foo", "bar"}, "NOT ARRAY")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotInList([]interface{}{"foo", "bar"}, "NOT ARRAY")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotInList([]interface{}{"foo", "bar"}, "NOT ARRAY")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myArray []interface{}
+			myMap   map[string]interface{}
+			myInt   int
+		)
+
+		array := NewArray(reporter, []interface{}{
+			123,
+			456,
+			[]interface{}{789, 567},
+			map[string]interface{}{"a": "b"},
+		})
+
+		array.InList(myArray{myInt(123.0), myInt(456.0), myArray{myInt(789.0), myInt(567.0)}, myMap{"a": "b"}})
+		array.chain.assertNotFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(myArray{myInt(123.0), myInt(456.0), myArray{myInt(789.0), myInt(567.0)}, myMap{"a": "b"}})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.InList(myArray{123.0, 456.0, myArray{789.0, 567.0}, myMap{"a": "b"}})
+		array.chain.assertNotFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(myArray{123.0, 456.0, myArray{789.0, 567.0}, myMap{"a": "b"}})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.InList(myArray{myInt(123), 456.0, myArray{myInt(789), 567.0}, myMap{"a": "b"}})
+		array.chain.assertNotFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(myArray{myInt(123), 456.0, myArray{myInt(789), 567.0}, myMap{"a": "b"}})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.InList(myArray{"123.0", "456.0", myArray{"789.0", "567.0"}, myMap{"a": "b"}})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(myArray{"123.0", "456.0", myArray{"789.0", "567.0"}, myMap{"a": "b"}})
+		array.chain.assertNotFailed(t)
+		array.chain.clearFailed()
+
+		array.InList(func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+
+		array.NotInList(func() {})
+		array.chain.assertFailed(t)
+		array.chain.clearFailed()
+	})
+
 }
 
 func TestArray_ConsistsOf(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -1572,40 +1572,40 @@ func TestArray_IsValueEqual(t *testing.T) {
 }
 
 func TestArray_Every(t *testing.T) {
-	t.Run("check value", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+	t.Run("check value", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{2, 4, 6})
 
 		invoked := 0
 		array.Every(func(_ int, val *Value) {
 			if v, ok := val.Raw().(float64); ok {
 				invoked++
-				assert.Equal(ts, 0, int(v)%2)
+				assert.Equal(t, 0, int(v)%2)
 			}
 		})
 
 		assert.Equal(t, 3, invoked)
-		array.chain.assertNotFailed(ts)
+		array.chain.assertNotFailed(t)
 	})
 
-	t.Run("check index", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+	t.Run("check index", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, 3})
 
 		invoked := 0
 		array.Every(func(idx int, val *Value) {
 			if v, ok := val.Raw().(float64); ok {
 				invoked++
-				assert.Equal(ts, idx, int(v)-1)
+				assert.Equal(t, idx, int(v)-1)
 			}
 		})
 
 		assert.Equal(t, 3, invoked)
-		array.chain.assertNotFailed(ts)
+		array.chain.assertNotFailed(t)
 	})
 
-	t.Run("empty array", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+	t.Run("empty array", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
 		invoked := 0
@@ -1614,11 +1614,11 @@ func TestArray_Every(t *testing.T) {
 		})
 
 		assert.Equal(t, 0, invoked)
-		array.chain.assertNotFailed(ts)
+		array.chain.assertNotFailed(t)
 	})
 
-	t.Run("one assertion fails", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+	t.Run("one assertion fails", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{"foo", "", "bar"})
 
 		invoked := 0
@@ -1628,11 +1628,11 @@ func TestArray_Every(t *testing.T) {
 		})
 
 		assert.Equal(t, 3, invoked)
-		array.chain.assertFailed(ts)
+		array.chain.assertFailed(t)
 	})
 
-	t.Run("all assertions fail", func(ts *testing.T) {
-		reporter := newMockReporter(ts)
+	t.Run("all assertions fail", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{"", "", ""})
 
 		invoked := 0
@@ -1642,27 +1642,27 @@ func TestArray_Every(t *testing.T) {
 		})
 
 		assert.Equal(t, 3, invoked)
-		array.chain.assertFailed(ts)
+		array.chain.assertFailed(t)
 	})
 }
 
 func TestArray_Transform(t *testing.T) {
-	t.Run("check index", func(ts *testing.T) {
+	t.Run("check index", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, 3})
 
 		newArray := array.Transform(func(idx int, val interface{}) interface{} {
 			if v, ok := val.(float64); ok {
-				assert.Equal(ts, idx, int(v)-1)
+				assert.Equal(t, idx, int(v)-1)
 			}
 			return val
 		})
 
 		assert.Equal(t, []interface{}{float64(1), float64(2), float64(3)}, newArray.value)
-		newArray.chain.assertNotFailed(ts)
+		newArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("transform value", func(ts *testing.T) {
+	t.Run("transform value", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{2, 4, 6})
 
@@ -1670,27 +1670,27 @@ func TestArray_Transform(t *testing.T) {
 			if v, ok := val.(float64); ok {
 				return int(v) * int(v)
 			}
-			ts.Errorf("failed transformation")
+			t.Errorf("failed transformation")
 			return nil
 		})
 
 		assert.Equal(t, []interface{}{float64(4), float64(16), float64(36)}, newArray.value)
-		newArray.chain.assertNotFailed(ts)
+		newArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("empty array", func(ts *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
 		newArray := array.Transform(func(_ int, _ interface{}) interface{} {
-			ts.Errorf("failed transformation")
+			t.Errorf("failed transformation")
 			return nil
 		})
 
-		newArray.chain.assertNotFailed(ts)
+		newArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{2, 4, 6})
 
@@ -1701,7 +1701,7 @@ func TestArray_Transform(t *testing.T) {
 }
 
 func TestArray_Filter(t *testing.T) {
-	t.Run("elements of same type", func(ts *testing.T) {
+	t.Run("elements of same type", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, 3, 4, 5, 6})
 
@@ -1716,7 +1716,7 @@ func TestArray_Filter(t *testing.T) {
 		filteredArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("elements of different types", func(ts *testing.T) {
+	t.Run("elements of different types", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{"foo", "bar", true, 1.0})
 
@@ -1731,7 +1731,7 @@ func TestArray_Filter(t *testing.T) {
 		filteredArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("empty array", func(ts *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
@@ -1746,7 +1746,7 @@ func TestArray_Filter(t *testing.T) {
 		filteredArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("no match", func(ts *testing.T) {
+	t.Run("no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{"foo", "bar", true, 1.0})
 
@@ -1761,7 +1761,7 @@ func TestArray_Filter(t *testing.T) {
 		filteredArray.chain.assertNotFailed(t)
 	})
 
-	t.Run("assertion fails", func(ts *testing.T) {
+	t.Run("assertion fails", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1.0, "foo", "bar", 4.0, "baz", 6.0})
 
@@ -1779,7 +1779,7 @@ func TestArray_Filter(t *testing.T) {
 }
 
 func TestArray_Find(t *testing.T) {
-	t.Run("elements of same type", func(ts *testing.T) {
+	t.Run("elements of same type", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, 3, 4, 5, 6})
 
@@ -1794,7 +1794,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertNotFailed(t)
 	})
 
-	t.Run("elements of different types", func(ts *testing.T) {
+	t.Run("elements of different types", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, "foo", true, "bar"})
 
@@ -1810,7 +1810,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertNotFailed(t)
 	})
 
-	t.Run("first match", func(ts *testing.T) {
+	t.Run("first match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, "foo", true, "bar"})
 
@@ -1826,7 +1826,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertNotFailed(t)
 	})
 
-	t.Run("no match", func(ts *testing.T) {
+	t.Run("no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, "foo", true, "bar"})
 
@@ -1841,7 +1841,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertFailed(t)
 	})
 
-	t.Run("empty array", func(ts *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
@@ -1856,7 +1856,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertFailed(t)
 	})
 
-	t.Run("predicate returns true, assertion fails, no match", func(ts *testing.T) {
+	t.Run("predicate returns true, assertion fails, no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -1872,7 +1872,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertFailed(t)
 	})
 
-	t.Run("predicate returns true, assertion fails, have match", func(ts *testing.T) {
+	t.Run("predicate returns true, assertion fails, have match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, "str"})
 
@@ -1888,7 +1888,7 @@ func TestArray_Find(t *testing.T) {
 		foundValue.chain.assertNotFailed(t)
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -1903,7 +1903,7 @@ func TestArray_Find(t *testing.T) {
 }
 
 func TestArray_FindAll(t *testing.T) {
-	t.Run("elements of same type", func(ts *testing.T) {
+	t.Run("elements of same type", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, 3, 4, 5, 6})
 
@@ -1925,7 +1925,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("elements of different types", func(ts *testing.T) {
+	t.Run("elements of different types", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1.0, "foo", true, "bar"})
 
@@ -1948,7 +1948,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("no match", func(ts *testing.T) {
+	t.Run("no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1.0, "foo", true, "bar"})
 
@@ -1970,7 +1970,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("empty array", func(ts *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
@@ -1992,7 +1992,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("predicate returns true, assertion fails, no match", func(ts *testing.T) {
+	t.Run("predicate returns true, assertion fails, no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -2015,7 +2015,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("predicate returns true, assertion fails, have matches", func(ts *testing.T) {
+	t.Run("predicate returns true, assertion fails, have matches", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{"foo", 1, 2, "bar"})
 
@@ -2038,7 +2038,7 @@ func TestArray_FindAll(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -2060,7 +2060,7 @@ func TestArray_FindAll(t *testing.T) {
 }
 
 func TestArray_NotFind(t *testing.T) {
-	t.Run("no match", func(ts *testing.T) {
+	t.Run("no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, "foo", true, "bar"})
 
@@ -2072,7 +2072,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertNotFailed(t)
 	})
 
-	t.Run("have match", func(ts *testing.T) {
+	t.Run("have match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, "foo", true, "bar"})
 
@@ -2084,7 +2084,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertFailed(t)
 	})
 
-	t.Run("empty array", func(ts *testing.T) {
+	t.Run("empty array", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{})
 
@@ -2096,7 +2096,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertNotFailed(t)
 	})
 
-	t.Run("predicate returns true, assertion fails, no match", func(ts *testing.T) {
+	t.Run("predicate returns true, assertion fails, no match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 
@@ -2109,7 +2109,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertNotFailed(t)
 	})
 
-	t.Run("predicate returns true, assertion fails, have match", func(ts *testing.T) {
+	t.Run("predicate returns true, assertion fails, have match", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2, "str"})
 
@@ -2122,7 +2122,7 @@ func TestArray_NotFind(t *testing.T) {
 		array.chain.assertFailed(t)
 	})
 
-	t.Run("invalid argument", func(ts *testing.T) {
+	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 		array := NewArray(reporter, []interface{}{1, 2})
 

--- a/array_test.go
+++ b/array_test.go
@@ -609,6 +609,90 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 	})
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myArray []interface{}
+			myInt   int
+		)
+
+		value := NewArray(reporter, []interface{}{123, 456, "foo"})
+		duplicateValue := NewArray(reporter, []interface{}{123, 123, "foo"})
+
+		assert.Equal(t, []interface{}{123.0, 456.0, "foo"}, value.Raw())
+
+		value.IsEqualUnordered(myArray{myInt(456), 123.0, "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(myArray{myInt(456), 123.0, "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(myArray{"foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(myArray{"foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(myArray{myInt(123), myInt(456), "foo", "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(myArray{myInt(123), myInt(456), "foo", "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(myArray{"foo", myInt(123), myInt(456), "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(myArray{"foo", myInt(123), myInt(456), "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(myArray{"123", "456", "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(myArray{"123", "456", "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(nil)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo"})
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.NotEqualUnordered(myArray{myInt(123), "foo"})
+		duplicateValue.chain.assertNotFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo", "foo"})
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.NotEqualUnordered(myArray{myInt(123), "foo", "foo"})
+		duplicateValue.chain.assertNotFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo", myInt(123)})
+		duplicateValue.chain.assertNotFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.NotEqualUnordered(myArray{myInt(123), "foo", myInt(123)})
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+	})
 }
 
 func TestArray_InList(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -1140,55 +1140,116 @@ func TestArray_ContainsAll(t *testing.T) {
 func TestArray_ContainsAny(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	value := NewArray(reporter, []interface{}{123, "foo"})
+	t.Run("basic", func(t *testing.T) {
+		value := NewArray(reporter, []interface{}{123, "foo"})
 
-	value.ContainsAny(123)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.ContainsAny(123)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.NotContainsAny(123)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotContainsAny(123)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.ContainsAny("foo", 123)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.ContainsAny("foo", 123)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.NotContainsAny("foo", 123)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotContainsAny("foo", 123)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.ContainsAny("foo", "foo")
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.ContainsAny("foo", "foo")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.NotContainsAny("foo", "foo")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotContainsAny("foo", "foo")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.ContainsAny(123, "foo", "FOO")
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.ContainsAny(123, "foo", "FOO")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.NotContainsAny(123, "foo", "FOO")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.NotContainsAny(123, "foo", "FOO")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.ContainsAny("FOO")
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.ContainsAny("FOO")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotContainsAny("FOO")
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.NotContainsAny("FOO")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-	value.ContainsAny([]interface{}{123, "foo"})
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+		value.ContainsAny([]interface{}{123, "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-	value.NotContainsAny([]interface{}{123, "foo"})
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+		value.NotContainsAny([]interface{}{123, "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+	})
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myInt   int
+			myArray []interface{}
+		)
+
+		value := NewArray(reporter, []interface{}{123, 789, "foo", []interface{}{567, 456}})
+
+		value.ContainsAny(myInt(123), 789.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(myInt(123), 789.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAny(789.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(789.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAny(567.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(567.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAny(myArray{567.0, 456.0})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(myArray{567.0, 456.0})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAny("789")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny("789")
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsAny(myArray{"567", 456.0})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsAny(myArray{"567", 456.0})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+	})
+
 }
 
 func TestArray_ContainsOnly(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -629,28 +629,12 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 
-		value.IsEqualUnordered(myArray{"foo"})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqualUnordered(myArray{"foo"})
+		value.IsEqualUnordered(myArray{456.0, myInt(123.0), "foo"})
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
 
-		value.IsEqualUnordered(myArray{myInt(123), myInt(456), "foo", "foo"})
+		value.NotEqualUnordered(myArray{456.0, myInt(123.0), "foo"})
 		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqualUnordered(myArray{myInt(123), myInt(456), "foo", "foo"})
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.IsEqualUnordered(myArray{"foo", myInt(123), myInt(456), "foo"})
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqualUnordered(myArray{"foo", myInt(123), myInt(456), "foo"})
-		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
 
 		value.IsEqualUnordered(myArray{"123", "456", "foo"})
@@ -658,6 +642,14 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		value.chain.clearFailed()
 
 		value.NotEqualUnordered(myArray{"123", "456", "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqualUnordered(myArray{"123.0", "456.0", "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqualUnordered(myArray{"123.0", "456.0", "foo"})
 		value.chain.assertNotFailed(t)
 		value.chain.clearFailed()
 
@@ -677,21 +669,38 @@ func TestArray_IsEqualUnordered(t *testing.T) {
 		duplicateValue.chain.assertNotFailed(t)
 		duplicateValue.chain.clearFailed()
 
-		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo", "foo"})
-		duplicateValue.chain.assertFailed(t)
-		duplicateValue.chain.clearFailed()
-
-		duplicateValue.NotEqualUnordered(myArray{myInt(123), "foo", "foo"})
+		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo", 123.0})
 		duplicateValue.chain.assertNotFailed(t)
 		duplicateValue.chain.clearFailed()
 
-		duplicateValue.IsEqualUnordered(myArray{myInt(123), "foo", myInt(123)})
+		duplicateValue.NotEqualUnordered(myArray{123.0, "foo", myInt(123)})
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.IsEqualUnordered(myArray{"123", "123", "foo"})
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.NotEqualUnordered(myArray{"123", "123", "foo"})
 		duplicateValue.chain.assertNotFailed(t)
 		duplicateValue.chain.clearFailed()
 
-		duplicateValue.NotEqualUnordered(myArray{myInt(123), "foo", myInt(123)})
+		duplicateValue.IsEqualUnordered(myArray{"123.0", "123.0", "foo"})
 		duplicateValue.chain.assertFailed(t)
 		duplicateValue.chain.clearFailed()
+
+		duplicateValue.NotEqualUnordered(myArray{"123.0", "123.0", "foo"})
+		duplicateValue.chain.assertNotFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.IsEqualUnordered(nil)
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+
+		duplicateValue.NotEqualUnordered(nil)
+		duplicateValue.chain.assertFailed(t)
+		duplicateValue.chain.clearFailed()
+
 	})
 }
 


### PR DESCRIPTION
PR for [issue 288](https://github.com/gavv/httpexpect/issues/288). 
Addresses Canonization tests:
- [x] `TestArray_IsEqualUnordered` 
- [x] `TestArray_InList`
- [x] `TestArray_ContainsAny`
- [x] `TestArray_ContainsOnly`
- [ ] `TestArray_Transform` (produced array should be in canonical form)