### PR TITLE
 Wip : Make request thread safe

### DIFF
--- a/request.go
+++ b/request.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ajg/form"
@@ -28,9 +29,9 @@ import (
 // Request provides methods to incrementally build http.Request object,
 // send it, and receive response.
 type Request struct {
-	noCopy noCopy
 	config Config
 	chain  *chain
+	mu     sync.RWMutex
 
 	redirectPolicy RedirectPolicy
 	maxRedirects   int
@@ -198,6 +199,9 @@ func (r *Request) Alias(name string) *Request {
 	opChain := r.chain.enter("Alias(%q)", name)
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	r.chain.setAlias(name)
 	return r
 }
@@ -213,6 +217,9 @@ func (r *Request) Alias(name string) *Request {
 func (r *Request) WithName(name string) *Request {
 	opChain := r.chain.enter("WithName()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -240,6 +247,9 @@ func (r *Request) WithName(name string) *Request {
 func (r *Request) WithMatcher(matcher func(*Response)) *Request {
 	opChain := r.chain.enter("WithMatcher()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -274,6 +284,9 @@ func (r *Request) WithMatcher(matcher func(*Response)) *Request {
 func (r *Request) WithTransformer(transform func(*http.Request)) *Request {
 	opChain := r.chain.enter("WithTransformer()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -315,6 +328,9 @@ func (r *Request) WithClient(client Client) *Request {
 	opChain := r.chain.enter("WithClient()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -351,6 +367,9 @@ func (r *Request) WithClient(client Client) *Request {
 func (r *Request) WithHandler(handler http.Handler) *Request {
 	opChain := r.chain.enter("WithHandler()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -401,6 +420,9 @@ func (r *Request) WithContext(ctx context.Context) *Request {
 	opChain := r.chain.enter("WithContext()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -442,6 +464,9 @@ func (r *Request) WithContext(ctx context.Context) *Request {
 func (r *Request) WithTimeout(timeout time.Duration) *Request {
 	opChain := r.chain.enter("WithTimeout()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -512,6 +537,9 @@ func (r *Request) WithRedirectPolicy(policy RedirectPolicy) *Request {
 	opChain := r.chain.enter("WithRedirectPolicy()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -543,6 +571,9 @@ func (r *Request) WithRedirectPolicy(policy RedirectPolicy) *Request {
 func (r *Request) WithMaxRedirects(maxRedirects int) *Request {
 	opChain := r.chain.enter("WithMaxRedirects()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -618,6 +649,9 @@ func (r *Request) WithRetryPolicy(policy RetryPolicy) *Request {
 	opChain := r.chain.enter("WithRetryPolicy()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -649,6 +683,9 @@ func (r *Request) WithRetryPolicy(policy RetryPolicy) *Request {
 func (r *Request) WithMaxRetries(maxRetries int) *Request {
 	opChain := r.chain.enter("WithMaxRetries()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -689,6 +726,9 @@ func (r *Request) WithMaxRetries(maxRetries int) *Request {
 func (r *Request) WithRetryDelay(minDelay, maxDelay time.Duration) *Request {
 	opChain := r.chain.enter("WithRetryDelay()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -741,6 +781,9 @@ func (r *Request) WithWebsocketUpgrade() *Request {
 	opChain := r.chain.enter("WithWebsocketUpgrade()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -771,6 +814,9 @@ func (r *Request) WithWebsocketUpgrade() *Request {
 func (r *Request) WithWebsocketDialer(dialer WebsocketDialer) *Request {
 	opChain := r.chain.enter("WithWebsocketDialer()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -811,6 +857,9 @@ func (r *Request) WithWebsocketDialer(dialer WebsocketDialer) *Request {
 func (r *Request) WithPath(key string, value interface{}) *Request {
 	opChain := r.chain.enter("WithPath()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -864,6 +913,9 @@ func (r *Request) WithPath(key string, value interface{}) *Request {
 func (r *Request) WithPathObject(object interface{}) *Request {
 	opChain := r.chain.enter("WithPathObject()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -983,7 +1035,11 @@ func (r *Request) WithQuery(key string, value interface{}) *Request {
 	if r.query == nil {
 		r.query = make(url.Values)
 	}
-	r.query.Add(key, fmt.Sprint(value))
+	func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.query.Add(key, fmt.Sprint(value))
+	}()
 
 	return r
 }
@@ -1013,6 +1069,9 @@ func (r *Request) WithQuery(key string, value interface{}) *Request {
 func (r *Request) WithQueryObject(object interface{}) *Request {
 	opChain := r.chain.enter("WithQueryObject()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1084,6 +1143,9 @@ func (r *Request) WithQueryString(query string) *Request {
 		return r
 	}
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if !r.checkOrder(opChain, "WithQueryString()") {
 		return r
 	}
@@ -1126,6 +1188,9 @@ func (r *Request) WithURL(urlStr string) *Request {
 	opChain := r.chain.enter("WithURL()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1164,6 +1229,9 @@ func (r *Request) WithHeaders(headers map[string]string) *Request {
 	opChain := r.chain.enter("WithHeaders()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1188,6 +1256,9 @@ func (r *Request) WithHeaders(headers map[string]string) *Request {
 func (r *Request) WithHeader(k, v string) *Request {
 	opChain := r.chain.enter("WithHeader()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1233,6 +1304,9 @@ func (r *Request) WithCookies(cookies map[string]string) *Request {
 	opChain := r.chain.enter("WithCookies()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1260,6 +1334,9 @@ func (r *Request) WithCookies(cookies map[string]string) *Request {
 func (r *Request) WithCookie(k, v string) *Request {
 	opChain := r.chain.enter("WithCookie()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1291,6 +1368,9 @@ func (r *Request) WithBasicAuth(username, password string) *Request {
 	opChain := r.chain.enter("WithBasicAuth()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1313,6 +1393,9 @@ func (r *Request) WithBasicAuth(username, password string) *Request {
 func (r *Request) WithHost(host string) *Request {
 	opChain := r.chain.enter("WithHost()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1338,6 +1421,9 @@ func (r *Request) WithHost(host string) *Request {
 func (r *Request) WithProto(proto string) *Request {
 	opChain := r.chain.enter("WithProto()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1386,6 +1472,9 @@ func (r *Request) WithChunked(reader io.Reader) *Request {
 	opChain := r.chain.enter("WithChunked()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1422,6 +1511,9 @@ func (r *Request) WithBytes(b []byte) *Request {
 	opChain := r.chain.enter("WithBytes()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1449,6 +1541,9 @@ func (r *Request) WithBytes(b []byte) *Request {
 func (r *Request) WithText(s string) *Request {
 	opChain := r.chain.enter("WithText()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1481,6 +1576,9 @@ func (r *Request) WithText(s string) *Request {
 func (r *Request) WithJSON(object interface{}) *Request {
 	opChain := r.chain.enter("WithJSON()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1535,6 +1633,9 @@ func (r *Request) WithJSON(object interface{}) *Request {
 func (r *Request) WithForm(object interface{}) *Request {
 	opChain := r.chain.enter("WithForm()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1609,6 +1710,9 @@ func (r *Request) WithFormField(key string, value interface{}) *Request {
 	opChain := r.chain.enter("WithFormField()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1667,6 +1771,9 @@ func (r *Request) WithFile(key, path string, reader ...io.Reader) *Request {
 	opChain := r.chain.enter("WithFile()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1704,6 +1811,9 @@ func (r *Request) WithFile(key, path string, reader ...io.Reader) *Request {
 func (r *Request) WithFileBytes(key, path string, data []byte) *Request {
 	opChain := r.chain.enter("WithFileBytes()")
 	defer opChain.leave()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	if opChain.failed() {
 		return r
@@ -1797,6 +1907,9 @@ func (r *Request) WithMultipart() *Request {
 	opChain := r.chain.enter("WithMultipart()")
 	defer opChain.leave()
 
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	if opChain.failed() {
 		return r
 	}
@@ -1835,16 +1948,57 @@ func (r *Request) Expect() *Response {
 	opChain := r.chain.enter("Expect()")
 	defer opChain.leave()
 
-	resp := r.expect(opChain)
+	var resp Request
 
-	if resp == nil {
-		resp = newResponse(responseOpts{
+	func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		resp = Request{
+			config: r.config,
+			chain:  r.chain,
+			mu:     r.mu,
+
+			redirectPolicy: r.redirectPolicy,
+			maxRedirects:   r.maxRedirects,
+
+			retryPolicy:   r.retryPolicy,
+			maxRetries:    r.maxRetries,
+			minRetryDelay: r.minRetryDelay,
+			maxRetryDelay: r.maxRetryDelay,
+			sleepFn:       r.sleepFn,
+
+			timeout: r.timeout,
+
+			httpReq: r.httpReq,
+			path:    r.path,
+			query:   r.query,
+
+			form:      r.form,
+			formbuf:   r.formbuf,
+			multipart: r.multipart,
+
+			bodySetter:   r.bodySetter,
+			typeSetter:   r.typeSetter,
+			forceType:    r.forceType,
+			expectCalled: r.expectCalled,
+
+			wsUpgrade: r.wsUpgrade,
+
+			transforms: r.transforms,
+			matchers:   r.matchers,
+		}
+	}()
+
+	response := resp.expect(opChain)
+
+	if response == nil {
+		response = newResponse(responseOpts{
 			config: r.config,
 			chain:  opChain,
 		})
 	}
 
-	return resp
+	return response
 }
 
 func (r *Request) expect(opChain *chain) *Response {


### PR DESCRIPTION
Initial commit to making request thread-safe

In this implementation, I Introduced a new request object whenever expect() is called to avoid data race. 
why expect?
Since expect() is the one that transfers the request object to matches and transformers.. we can supply a new Request object to them so that each go-routine has its own copy.

Things that are going wrong here are
-  While creating a new request object, we are also copying locks.
-  `checkOrder` relies on struct var `expectCalled` and since a new Request object is being created, `expectCalled` is not being updated and hence fails.
- `Request_Redirects` also fails 
