### PR TITLE
Refactor string unit tests

### DIFF
--- a/string_test.go
+++ b/string_test.go
@@ -180,8 +180,6 @@ func TestString_Length(t *testing.T) {
 }
 
 func TestString_IsEmpty(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	cases := map[string]struct {
 		str       string
 		wantEmpty bool
@@ -192,21 +190,20 @@ func TestString_IsEmpty(t *testing.T) {
 
 	for name, value := range cases {
 		t.Run(name, func(t *testing.T) {
-			childValue := NewString(reporter, value.str)
+			reporter := newMockReporter(t)
 
 			if value.wantEmpty {
-				childValue.IsEmpty()
-				childValue.chain.assertNotFailed(t)
+				NewString(reporter, value.str).IsEmpty().
+					chain.assertNotFailed(t)
 
-				childValue.NotEmpty()
-				childValue.chain.assertFailed(t)
+				NewString(reporter, value.str).NotEmpty().
+					chain.assertFailed(t)
 			} else {
-				childValue.IsEmpty()
-				childValue.chain.assertFailed(t)
-				childValue.chain.clearFailed()
+				NewString(reporter, value.str).IsEmpty().
+					chain.assertFailed(t)
 
-				childValue.NotEmpty()
-				childValue.chain.assertNotFailed(t)
+				NewString(reporter, value.str).NotEmpty().
+					chain.assertNotFailed(t)
 			}
 		})
 	}
@@ -484,8 +481,6 @@ func TestString_MatchInvalid(t *testing.T) {
 }
 
 func TestString_IsAscii(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	cases := []struct {
 		str       string
 		wantASCII bool
@@ -499,29 +494,26 @@ func TestString_IsAscii(t *testing.T) {
 
 	for _, value := range cases {
 		t.Run(value.str, func(t *testing.T) {
-			childValue := NewString(reporter, value.str)
+			reporter := newMockReporter(t)
 
 			if value.wantASCII {
-				childValue.IsASCII()
-				childValue.chain.assertNotFailed(t)
+				NewString(reporter, value.str).IsASCII().
+					chain.assertNotFailed(t)
 
-				childValue.NotASCII()
-				childValue.chain.assertFailed(t)
+				NewString(reporter, value.str).NotASCII().
+					chain.assertFailed(t)
 			} else {
-				childValue.IsASCII()
-				childValue.chain.assertFailed(t)
-				childValue.chain.clearFailed()
+				NewString(reporter, value.str).IsASCII().
+					chain.assertFailed(t)
 
-				childValue.NotASCII()
-				childValue.chain.assertNotFailed(t)
+				NewString(reporter, value.str).NotASCII().
+					chain.assertNotFailed(t)
 			}
 		})
 	}
 }
 
 func TestString_AsNumber(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	cases := map[string]struct {
 		str         string
 		base        []int
@@ -599,32 +591,32 @@ func TestString_AsNumber(t *testing.T) {
 
 	for name, value := range cases {
 		t.Run(name, func(t *testing.T) {
-			childValue := NewString(reporter, value.str)
-			num := childValue.AsNumber(value.base...)
+			reporter := newMockReporter(t)
+
+			str := NewString(reporter, value.str)
+			num := str.AsNumber(value.base...)
 
 			if value.fail {
-				childValue.chain.assertFailed(t)
+				str.chain.assertFailed(t)
 				num.chain.assertFailed(t)
 				assert.Equal(t, float64(0), num.Raw())
 			} else {
-				childValue.chain.assertNotFailed(t)
+				str.chain.assertNotFailed(t)
 				num.chain.assertNotFailed(t)
 				assert.Equal(t, value.expectedNum, num.Raw())
 			}
-
 		})
 	}
 }
 
 func TestString_AsBoolean(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	trueValues := []string{"true", "True"}
 	falseValues := []string{"false", "False"}
 	badValues := []string{"TRUE", "FALSE", "t", "f", "1", "0", "bad"}
 
 	for _, str := range trueValues {
 		t.Run(str, func(t *testing.T) {
+			reporter := newMockReporter(t)
 			value := NewString(reporter, str)
 
 			b := value.AsBoolean()
@@ -636,6 +628,7 @@ func TestString_AsBoolean(t *testing.T) {
 
 	for _, str := range falseValues {
 		t.Run(str, func(t *testing.T) {
+			reporter := newMockReporter(t)
 			value := NewString(reporter, str)
 
 			b := value.AsBoolean()
@@ -647,6 +640,7 @@ func TestString_AsBoolean(t *testing.T) {
 
 	for _, str := range badValues {
 		t.Run(str, func(t *testing.T) {
+			reporter := newMockReporter(t)
 			value := NewString(reporter, str)
 
 			b := value.AsBoolean()
@@ -656,29 +650,36 @@ func TestString_AsBoolean(t *testing.T) {
 }
 
 func TestString_AsDateTime(t *testing.T) {
-	reporter := newMockReporter(t)
-
 	t.Run("default_formats_RFC1123+GMT", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		value := NewString(reporter, "Tue, 15 Nov 1994 08:12:31 GMT")
+
 		dt := value.AsDateTime()
 		value.chain.assertNotFailed(t)
 		dt.chain.assertNotFailed(t)
+
 		assert.True(t, time.Date(1994, 11, 15, 8, 12, 31, 0, time.UTC).Equal(dt.Raw()))
 	})
 
 	t.Run("RFC822", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		value := NewString(reporter, "15 Nov 94 08:12 GMT")
+
 		dt := value.AsDateTime(time.RFC822)
 		value.chain.assertNotFailed(t)
 		dt.chain.assertNotFailed(t)
+
 		assert.True(t, time.Date(1994, 11, 15, 8, 12, 0, 0, time.UTC).Equal(dt.Raw()))
 	})
 
 	t.Run("bad_input", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		value := NewString(reporter, "bad")
+
 		dt := value.AsDateTime()
 		value.chain.assertFailed(t)
 		dt.chain.assertFailed(t)
+
 		assert.True(t, time.Unix(0, 0).Equal(dt.Raw()))
 	})
 
@@ -700,7 +701,9 @@ func TestString_AsDateTime(t *testing.T) {
 		t.Run("default_formats_"+f, func(t *testing.T) {
 			str := time.Now().Format(f)
 
+			reporter := newMockReporter(t)
 			value := NewString(reporter, str)
+
 			dt := value.AsDateTime()
 			dt.chain.assertNotFailed(t)
 		})
@@ -708,7 +711,9 @@ func TestString_AsDateTime(t *testing.T) {
 		t.Run("all_formats_"+f, func(t *testing.T) {
 			str := time.Now().Format(f)
 
+			reporter := newMockReporter(t)
 			value := NewString(reporter, str)
+
 			dt := value.AsDateTime(formats...)
 			dt.chain.assertNotFailed(t)
 		})
@@ -716,7 +721,9 @@ func TestString_AsDateTime(t *testing.T) {
 		t.Run("same_format_"+f, func(t *testing.T) {
 			str := time.Now().Format(f)
 
+			reporter := newMockReporter(t)
 			value := NewString(reporter, str)
+
 			dt := value.AsDateTime(f)
 			dt.chain.assertNotFailed(t)
 		})
@@ -725,7 +732,9 @@ func TestString_AsDateTime(t *testing.T) {
 			t.Run("different_format_"+f, func(t *testing.T) {
 				str := time.Now().Format(f)
 
+				reporter := newMockReporter(t)
 				value := NewString(reporter, str)
+
 				dt := value.AsDateTime(formats[0])
 				dt.chain.assertFailed(t)
 			})

--- a/string_test.go
+++ b/string_test.go
@@ -179,7 +179,7 @@ func TestString_Length(t *testing.T) {
 	assert.Equal(t, 7.0, num.Raw())
 }
 
-func TestString_IsEmpty(t *testing.T) {
+func TestString_Empty(t *testing.T) {
 	reporter := newMockReporter(t)
 
 	cases := map[string]struct {
@@ -197,7 +197,6 @@ func TestString_IsEmpty(t *testing.T) {
 			if value.wantEmpty {
 				childValue.IsEmpty()
 				childValue.chain.assertNotFailed(t)
-				childValue.chain.clearFailed()
 
 				childValue.NotEmpty()
 				childValue.chain.assertFailed(t)
@@ -505,7 +504,6 @@ func TestString_Ascii(t *testing.T) {
 			if value.wantASCII {
 				childValue.IsASCII()
 				childValue.chain.assertNotFailed(t)
-				childValue.chain.clearFailed()
 
 				childValue.NotASCII()
 				childValue.chain.assertFailed(t)

--- a/string_test.go
+++ b/string_test.go
@@ -573,21 +573,21 @@ func TestString_AsNumber(t *testing.T) {
 			fail:        false,
 			expectedNum: float64(0x4000000000000000),
 		},
-		"default_float_percision_max": {
+		"default_float_precision_max": {
 			str:  "4611686018427387905",
 			fail: true,
 		},
-		"base10_float_percision_max": {
+		"base10_float_precision_max": {
 			str:  "4611686018427387905",
 			base: []int{10},
 			fail: true,
 		},
-		"base16_float_percision_max": {
+		"base16_float_precision_max": {
 			str:  "8000000000000001",
 			base: []int{16},
 			fail: true,
 		},
-		"base16_float_percision_min": {
+		"base16_float_precision_min": {
 			str:  "-4000000000000001",
 			base: []int{16},
 			fail: true,

--- a/string_test.go
+++ b/string_test.go
@@ -179,7 +179,7 @@ func TestString_Length(t *testing.T) {
 	assert.Equal(t, 7.0, num.Raw())
 }
 
-func TestString_Empty(t *testing.T) {
+func TestString_IsEmpty(t *testing.T) {
 	reporter := newMockReporter(t)
 
 	cases := map[string]struct {
@@ -483,7 +483,7 @@ func TestString_MatchInvalid(t *testing.T) {
 	value.chain.clearFailed()
 }
 
-func TestString_Ascii(t *testing.T) {
+func TestString_IsAscii(t *testing.T) {
 	reporter := newMockReporter(t)
 
 	cases := []struct {

--- a/string_test.go
+++ b/string_test.go
@@ -182,25 +182,25 @@ func TestString_Length(t *testing.T) {
 func TestString_Empty(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	value1 := NewString(reporter, "")
+	value := NewString(reporter, "")
 
-	value1.IsEmpty()
-	value1.chain.assertNotFailed(t)
-	value1.chain.clearFailed()
+	value.IsEmpty()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 
-	value1.NotEmpty()
-	value1.chain.assertFailed(t)
-	value1.chain.clearFailed()
+	value.NotEmpty()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
-	value2 := NewString(reporter, "a")
+	value = NewString(reporter, "a")
 
-	value2.IsEmpty()
-	value2.chain.assertFailed(t)
-	value2.chain.clearFailed()
+	value.IsEmpty()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
-	value2.NotEmpty()
-	value2.chain.assertNotFailed(t)
-	value2.chain.clearFailed()
+	value.NotEmpty()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 }
 
 func TestString_Equal(t *testing.T) {
@@ -477,150 +477,166 @@ func TestString_MatchInvalid(t *testing.T) {
 func TestString_IsAscii(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	value1 := NewString(reporter, "Ascii")
-	value1.IsASCII()
-	value1.chain.assertNotFailed(t)
-	value1.chain.clearFailed()
+	value := NewString(reporter, "Ascii")
+	value.IsASCII()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 
-	value2 := NewString(reporter, "Ascii is アスキー")
-	value2.IsASCII()
-	value2.chain.assertFailed(t)
-	value2.chain.clearFailed()
+	value = NewString(reporter, "Ascii is アスキー")
+	value.IsASCII()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
-	value3 := NewString(reporter, "アスキー")
-	value3.IsASCII()
-	value3.chain.assertFailed(t)
-	value3.chain.clearFailed()
+	value = NewString(reporter, "アスキー")
+	value.IsASCII()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
-	value4 := NewString(reporter, string(rune(127)))
-	value4.IsASCII()
-	value4.chain.assertNotFailed(t)
-	value4.chain.clearFailed()
+	value = NewString(reporter, string(rune(127)))
+	value.IsASCII()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 
-	value5 := NewString(reporter, string(rune(128)))
-	value5.IsASCII()
-	value5.chain.assertFailed(t)
-	value5.chain.clearFailed()
+	value = NewString(reporter, string(rune(128)))
+	value.IsASCII()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 }
 
 func TestString_NotAscii(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	value1 := NewString(reporter, "Ascii")
-	value1.NotASCII()
-	value1.chain.assertFailed(t)
-	value1.chain.clearFailed()
+	value := NewString(reporter, "Ascii")
+	value.NotASCII()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
-	value2 := NewString(reporter, "Ascii is アスキー")
-	value2.NotASCII()
-	value2.chain.assertNotFailed(t)
-	value2.chain.clearFailed()
+	value = NewString(reporter, "Ascii is アスキー")
+	value.NotASCII()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 
-	value3 := NewString(reporter, "アスキー")
-	value3.NotASCII()
-	value3.chain.assertNotFailed(t)
-	value3.chain.clearFailed()
+	value = NewString(reporter, "アスキー")
+	value.NotASCII()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 
-	value4 := NewString(reporter, string(rune(127)))
-	value4.NotASCII()
-	value4.chain.assertFailed(t)
-	value4.chain.clearFailed()
+	value = NewString(reporter, string(rune(127)))
+	value.NotASCII()
+	value.chain.assertFailed(t)
+	value.chain.clearFailed()
 
-	value5 := NewString(reporter, string(rune(128)))
-	value5.NotASCII()
-	value5.chain.assertNotFailed(t)
-	value5.chain.clearFailed()
+	value = NewString(reporter, string(rune(128)))
+	value.NotASCII()
+	value.chain.assertNotFailed(t)
+	value.chain.clearFailed()
 }
 
 func TestString_AsNumber(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	t.Run("default_base", func(t *testing.T) {
-		value1 := NewString(reporter, "1234567")
-		num1 := value1.AsNumber()
-		value1.chain.assertNotFailed(t)
-		num1.chain.assertNotFailed(t)
-		assert.Equal(t, float64(1234567), num1.Raw())
-
-		value2 := NewString(reporter, "11.22")
-		num2 := value2.AsNumber()
-		value2.chain.assertNotFailed(t)
-		num2.chain.assertNotFailed(t)
-		assert.Equal(t, float64(11.22), num2.Raw())
-
-		value3 := NewString(reporter, "a1")
-		num3 := value3.AsNumber()
-		value3.chain.assertFailed(t)
-		num3.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num3.Raw())
+	t.Run("default_base_integer", func(t *testing.T) {
+		value := NewString(reporter, "1234567")
+		num := value.AsNumber()
+		value.chain.assertNotFailed(t)
+		num.chain.assertNotFailed(t)
+		assert.Equal(t, float64(1234567), num.Raw())
 	})
 
-	t.Run("base10", func(t *testing.T) {
-		value1 := NewString(reporter, "100")
-		num1 := value1.AsNumber(10)
-		value1.chain.assertNotFailed(t)
-		num1.chain.assertNotFailed(t)
-		assert.Equal(t, float64(100), num1.Raw())
-
-		value2 := NewString(reporter, "11.22")
-		num2 := value2.AsNumber(10)
-		value2.chain.assertNotFailed(t)
-		num2.chain.assertNotFailed(t)
-		assert.Equal(t, float64(11.22), num2.Raw())
+	t.Run("default_base_float", func(t *testing.T) {
+		value := NewString(reporter, "11.22")
+		num := value.AsNumber()
+		value.chain.assertNotFailed(t)
+		num.chain.assertNotFailed(t)
+		assert.Equal(t, float64(11.22), num.Raw())
 	})
 
-	t.Run("base16", func(t *testing.T) {
-		value1 := NewString(reporter, "100")
-		num1 := value1.AsNumber(16)
-		value1.chain.assertNotFailed(t)
-		num1.chain.assertNotFailed(t)
-		assert.Equal(t, float64(0x100), num1.Raw())
-
-		value2 := NewString(reporter, "11.22")
-		num2 := value2.AsNumber(16)
-		value2.chain.assertFailed(t)
-		num2.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num2.Raw())
-
-		value3 := NewString(reporter, "4000000000000000")
-		num3 := value3.AsNumber(16)
-		value3.chain.assertNotFailed(t)
-		num3.chain.assertNotFailed(t)
-		assert.Equal(t, float64(0x4000000000000000), num3.Raw())
+	t.Run("default_base_bad", func(t *testing.T) {
+		value := NewString(reporter, "a1")
+		num := value.AsNumber()
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
 	})
 
-	t.Run("float_precision", func(t *testing.T) {
-		value1 := NewString(reporter, "4611686018427387905")
-		num1 := value1.AsNumber()
-		value1.chain.assertFailed(t)
-		num1.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num1.Raw())
+	t.Run("base10_integer", func(t *testing.T) {
+		value := NewString(reporter, "100")
+		num := value.AsNumber(10)
+		value.chain.assertNotFailed(t)
+		num.chain.assertNotFailed(t)
+		assert.Equal(t, float64(100), num.Raw())
+	})
 
-		value2 := NewString(reporter, "4611686018427387905")
-		num2 := value2.AsNumber(10)
-		value2.chain.assertFailed(t)
-		num2.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num2.Raw())
+	t.Run("base10_float", func(t *testing.T) {
+		value := NewString(reporter, "11.22")
+		num := value.AsNumber(10)
+		value.chain.assertNotFailed(t)
+		num.chain.assertNotFailed(t)
+		assert.Equal(t, float64(11.22), num.Raw())
+	})
 
-		value3 := NewString(reporter, "8000000000000001")
-		num3 := value3.AsNumber(16)
-		value3.chain.assertFailed(t)
-		num3.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num3.Raw())
+	t.Run("base16_integer", func(t *testing.T) {
+		value := NewString(reporter, "100")
+		num := value.AsNumber(16)
+		value.chain.assertNotFailed(t)
+		num.chain.assertNotFailed(t)
+		assert.Equal(t, float64(0x100), num.Raw())
+	})
 
-		value4 := NewString(reporter, "-4000000000000001")
-		num4 := value4.AsNumber(16)
-		value4.chain.assertFailed(t)
-		num4.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num4.Raw())
+	t.Run("base16_float", func(t *testing.T) {
+		value := NewString(reporter, "11.22")
+		num := value.AsNumber(16)
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
+	})
+
+	t.Run("base16_large_integer", func(t *testing.T) {
+		value := NewString(reporter, "4000000000000000")
+		num := value.AsNumber(16)
+		value.chain.assertNotFailed(t)
+		num.chain.assertNotFailed(t)
+		assert.Equal(t, float64(0x4000000000000000), num.Raw())
+	})
+
+	t.Run("default_base_float_precision", func(t *testing.T) {
+		value := NewString(reporter, "4611686018427387905")
+		num := value.AsNumber()
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
+	})
+
+	t.Run("base10_float_precision", func(t *testing.T) {
+		value := NewString(reporter, "4611686018427387905")
+		num := value.AsNumber(10)
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
+	})
+
+	t.Run("base16_float_precision_max", func(t *testing.T) {
+		value := NewString(reporter, "8000000000000001")
+		num := value.AsNumber(16)
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
+	})
+
+	t.Run("base16_float_precision_min", func(t *testing.T) {
+		value := NewString(reporter, "-4000000000000001")
+		num := value.AsNumber(16)
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
 	})
 
 	t.Run("multiple_base", func(t *testing.T) {
-		value1 := NewString(reporter, "100")
-		num1 := value1.AsNumber(10, 16)
-		value1.chain.assertFailed(t)
-		num1.chain.assertFailed(t)
-		assert.Equal(t, float64(0), num1.Raw())
+		value := NewString(reporter, "100")
+		num := value.AsNumber(10, 16)
+		value.chain.assertFailed(t)
+		num.chain.assertFailed(t)
+		assert.Equal(t, float64(0), num.Raw())
 	})
 }
 
@@ -666,24 +682,28 @@ func TestString_AsBoolean(t *testing.T) {
 func TestString_AsDateTime(t *testing.T) {
 	reporter := newMockReporter(t)
 
-	t.Run("basic", func(t *testing.T) {
-		value1 := NewString(reporter, "Tue, 15 Nov 1994 08:12:31 GMT")
-		dt1 := value1.AsDateTime()
-		value1.chain.assertNotFailed(t)
-		dt1.chain.assertNotFailed(t)
-		assert.True(t, time.Date(1994, 11, 15, 8, 12, 31, 0, time.UTC).Equal(dt1.Raw()))
+	t.Run("default_formats_RFC1123+GMT", func(t *testing.T) {
+		value := NewString(reporter, "Tue, 15 Nov 1994 08:12:31 GMT")
+		dt := value.AsDateTime()
+		value.chain.assertNotFailed(t)
+		dt.chain.assertNotFailed(t)
+		assert.True(t, time.Date(1994, 11, 15, 8, 12, 31, 0, time.UTC).Equal(dt.Raw()))
+	})
 
-		value2 := NewString(reporter, "15 Nov 94 08:12 GMT")
-		dt2 := value2.AsDateTime(time.RFC822)
-		value2.chain.assertNotFailed(t)
-		dt2.chain.assertNotFailed(t)
-		assert.True(t, time.Date(1994, 11, 15, 8, 12, 0, 0, time.UTC).Equal(dt2.Raw()))
+	t.Run("RFC822", func(t *testing.T) {
+		value := NewString(reporter, "15 Nov 94 08:12 GMT")
+		dt := value.AsDateTime(time.RFC822)
+		value.chain.assertNotFailed(t)
+		dt.chain.assertNotFailed(t)
+		assert.True(t, time.Date(1994, 11, 15, 8, 12, 0, 0, time.UTC).Equal(dt.Raw()))
+	})
 
-		value3 := NewString(reporter, "bad")
-		dt3 := value3.AsDateTime()
-		value3.chain.assertFailed(t)
-		dt3.chain.assertFailed(t)
-		assert.True(t, time.Unix(0, 0).Equal(dt3.Raw()))
+	t.Run("bad_input", func(t *testing.T) {
+		value := NewString(reporter, "bad")
+		dt := value.AsDateTime()
+		value.chain.assertFailed(t)
+		dt.chain.assertFailed(t)
+		assert.True(t, time.Unix(0, 0).Equal(dt.Raw()))
 	})
 
 	formats := []string{
@@ -701,27 +721,39 @@ func TestString_AsDateTime(t *testing.T) {
 	}
 
 	for n, f := range formats {
-		t.Run(f, func(t *testing.T) {
+		t.Run("default_formats_"+f, func(t *testing.T) {
 			str := time.Now().Format(f)
 
-			value1 := NewString(reporter, str)
-			dt1 := value1.AsDateTime()
-			dt1.chain.assertNotFailed(t)
-
-			value2 := NewString(reporter, str)
-			dt2 := value2.AsDateTime(formats...)
-			dt2.chain.assertNotFailed(t)
-
-			value3 := NewString(reporter, str)
-			dt3 := value3.AsDateTime(f)
-			dt3.chain.assertNotFailed(t)
-
-			if n != 0 {
-				value4 := NewString(reporter, str)
-				dt4 := value4.AsDateTime(formats[0])
-				dt4.chain.assertFailed(t)
-			}
+			value := NewString(reporter, str)
+			dt := value.AsDateTime()
+			dt.chain.assertNotFailed(t)
 		})
+
+		t.Run("all_formats_"+f, func(t *testing.T) {
+			str := time.Now().Format(f)
+
+			value := NewString(reporter, str)
+			dt := value.AsDateTime(formats...)
+			dt.chain.assertNotFailed(t)
+		})
+
+		t.Run("same_format_"+f, func(t *testing.T) {
+			str := time.Now().Format(f)
+
+			value := NewString(reporter, str)
+			dt := value.AsDateTime(f)
+			dt.chain.assertNotFailed(t)
+		})
+
+		if n != 0 {
+			t.Run("different_format_"+f, func(t *testing.T) {
+				str := time.Now().Format(f)
+
+				value := NewString(reporter, str)
+				dt := value.AsDateTime(formats[0])
+				dt.chain.assertFailed(t)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
This PR addresses refactoring the following unit tests from #284:
- [x] TestString_Empty
- [x] TestString_IsAscii
- [x] TestString_NotAscii
- [x] TestString_AsNumber
- [x] TestString_AsDateTime

I updated `TestString_IsAscii` and `TestString_NotAscii` to just reuse the same variable, `value` since it was simple and the formatting was similar to other tests. However, we could also update it to be one of the following formats instead:
* Format would be similar to TestString_AsBoolean and this could also make it easier to add additional test cases in the future
```go
func TestString_IsAscii(t *testing.T) {
	reporter := newMockReporter(t)

	asciiValues := []string{
		"Ascii",
		string(rune(127)),
	}

	notAsciiValues := []string{
		"Ascii is アスキー",
		"アスキー",
		string(rune(128)),
	}

	for _, str := range asciiValues {
		t.Run(str, func(t *testing.T) {
			value := NewString(reporter, str)

			value.IsASCII()
			value.chain.assertNotFailed(t)
		})
	}

	for _, str := range notAsciiValues {
		t.Run(str, func(t *testing.T) {
			value := NewString(reporter, str)

			value.IsASCII()
			value.chain.assertFailed(t)
		})
	}
}
```

* Alternatively, we could use a more table-driven style.
```go
func TestString_IsAscii(t *testing.T) {
	reporter := newMockReporter(t)

	cases := []struct {
		str  string
		fail bool
	}{
		{"Ascii", false},
		{string(rune(127)), false},
		{"Ascii is アスキー", true},
		{"アスキー", true},
		{string(rune(128)), true},
	}

	for _, value := range cases {
		t.Run(value.str, func(t *testing.T) {
			childValue := NewString(reporter, value.str)

			childValue.IsASCII()

			if value.fail {
				childValue.chain.assertFailed(t)
			} else {
				childValue.chain.assertNotFailed(t)
			}
		})
	}
}
```
  
I broke out `TestString_AsNumber` and `TestString_AsDateTime` into additional subtests to address the additional variables. If the subtest names should be updated, let me know.

We could also do something more table driven for those two tests as well. Like this:
```go
func TestString_AsNumber(t *testing.T) {
	reporter := newMockReporter(t)

	cases := map[string]struct {
		str         string
		base        []int
		fail        bool
		expectedNum float64
	}{
		"default_base_integer": {
			str:         "1234567",
			fail:        false,
			expectedNum: float64(1234567),
		},
		"default_base_float": {
			str:         "11.22",
			fail:        false,
			expectedNum: float64(11.22),
		},
		"default_base_bad": {
			str:  "a1",
			fail: true,
		},
		"base10_integer": {
			str:         "100",
			base:        []int{10},
			fail:        false,
			expectedNum: float64(100),
		},
		"base10_float": {
			str:         "11.22",
			base:        []int{10},
			fail:        false,
			expectedNum: float64(11.22),
		},
		"base16_integer": {
			str:         "100",
			base:        []int{16},
			fail:        false,
			expectedNum: float64(0x100),
		},
		"base16_float": {
			str:  "11.22",
			base: []int{16},
			fail: true,
		},
		"base16_large_integer": {
			str:         "4000000000000000",
			base:        []int{16},
			fail:        false,
			expectedNum: float64(0x4000000000000000),
		},
		"default_float_percision_max": {
			str:  "4611686018427387905",
			fail: true,
		},
		"base10_float_percision_max": {
			str:  "4611686018427387905",
			base: []int{10},
			fail: true,
		},
		"base16_float_percision_max": {
			str:  "8000000000000001",
			base: []int{16},
			fail: true,
		},
		"base16_float_percision_min": {
			str:  "-4000000000000001",
			base: []int{16},
			fail: true,
		},
		"multiple_base": {
			str:  "100",
			base: []int{10, 16},
			fail: true,
		},
	}

	for name, value := range cases {
		t.Run(name, func(t *testing.T) {
			childValue := NewString(reporter, value.str)
			num := childValue.AsNumber(value.base...)

			if value.fail {
				childValue.chain.assertFailed(t)
				num.chain.assertFailed(t)
				assert.Equal(t, float64(0), num.Raw())
			} else {
				childValue.chain.assertNotFailed(t)
				num.chain.assertNotFailed(t)
				assert.Equal(t, value.expectedNum, num.Raw())
			}

		})
	}
}
```

Let me know if there's any issues. I plan to use separate PRs for refactoring the other tests mentioned in #284 after this one looks good.