### PR TITLE
 Additional Canonization tests for objects

### DIFF
--- a/object_test.go
+++ b/object_test.go
@@ -641,6 +641,33 @@ func TestObject_InList(t *testing.T) {
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 	})
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myMap map[string]interface{}
+			myInt int
+		)
+
+		reporter := newMockReporter(t)
+
+		value := NewObject(reporter, map[string]interface{}{"foo": 123, "bar": 456})
+
+		value.InList(myMap{"foo": 123.0, "bar": 456.0})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotInList(myMap{"foo": 123.0, "bar": 456.0})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.InList(myMap{"foo": "123", "bar": myInt(456.0)})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotInList(myMap{"foo": "123", "bar": myInt(456.0)})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+	})
 }
 
 func TestObject_ContainsKey(t *testing.T) {

--- a/object_test.go
+++ b/object_test.go
@@ -783,7 +783,6 @@ func TestObject_ContainsValue(t *testing.T) {
 
 	t.Run("canonization", func(t *testing.T) {
 		type (
-			myMap map[string]interface{}
 			myInt int
 		)
 
@@ -791,16 +790,8 @@ func TestObject_ContainsValue(t *testing.T) {
 
 		value := NewObject(reporter, map[string]interface{}{"foo": 123, "bar": 789})
 
-		value.ContainsValue(789.0)
+		value.ContainsValue(myInt(789.0))
 		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotContainsValue(789.0)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.ContainsValue("123")
-		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 
 		value.NotContainsValue(myInt(789.0))

--- a/object_test.go
+++ b/object_test.go
@@ -780,6 +780,33 @@ func TestObject_ContainsValue(t *testing.T) {
 		value.chain.assertFailed(t)
 		value.chain.clearFailed()
 	})
+
+	t.Run("canonization", func(t *testing.T) {
+		type (
+			myMap map[string]interface{}
+			myInt int
+		)
+
+		reporter := newMockReporter(t)
+
+		value := NewObject(reporter, map[string]interface{}{"foo": 123, "bar": 789})
+
+		value.ContainsValue(789.0)
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsValue(789.0)
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.ContainsValue("123")
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotContainsValue(myInt(789.0))
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+	})
 }
 
 func TestObject_ContainsSubset(t *testing.T) {


### PR DESCRIPTION
PR for issue #298 

Add canonization subtests for:
 - [x] TestObject_InList
 - [x]  TestObject_ContainsValue