### PR TITLE
Convert unit tests into subtest and to be table-driven

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -423,12 +423,57 @@ func TestArray_IsEqual(t *testing.T) {
 		value.chain.clearFailed()
 	})
 
-	t.Run("types", func(t *testing.T) {
+	t.Run("strings", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value1 := NewArray(reporter, []interface{}{"foo", "bar"})
-		value2 := NewArray(reporter, []interface{}{123, 456})
-		value3 := NewArray(reporter, []interface{}{
+		value := NewArray(reporter, []interface{}{"foo", "bar"})
+
+		value.IsEqual([]string{"foo", "bar"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqual([]string{"bar", "foo"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual([]string{"foo", "bar"})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual([]string{"bar", "foo"})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+	})
+
+	t.Run("numbers", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		value := NewArray(reporter, []interface{}{123, 456})
+
+		value.IsEqual([]int{123, 456})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+
+		value.IsEqual([]int{456, 123})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual([]int{123, 456})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
+
+		value.NotEqual([]int{456, 123})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		type S struct {
+			Foo int `json:"foo"`
+		}
+
+		value := NewArray(reporter, []interface{}{
 			map[string]interface{}{
 				"foo": 123,
 			},
@@ -437,57 +482,21 @@ func TestArray_IsEqual(t *testing.T) {
 			},
 		})
 
-		value1.IsEqual([]string{"foo", "bar"})
-		value1.chain.assertNotFailed(t)
-		value1.chain.clearFailed()
+		value.IsEqual([]S{{123}, {456}})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 
-		value1.IsEqual([]string{"bar", "foo"})
-		value1.chain.assertFailed(t)
-		value1.chain.clearFailed()
+		value.IsEqual([]S{{456}, {123}})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-		value1.NotEqual([]string{"foo", "bar"})
-		value1.chain.assertFailed(t)
-		value1.chain.clearFailed()
+		value.NotEqual([]S{{123}, {456}})
+		value.chain.assertFailed(t)
+		value.chain.clearFailed()
 
-		value1.NotEqual([]string{"bar", "foo"})
-		value1.chain.assertNotFailed(t)
-		value1.chain.clearFailed()
-
-		value2.IsEqual([]int{123, 456})
-		value2.chain.assertNotFailed(t)
-		value2.chain.clearFailed()
-
-		value2.IsEqual([]int{456, 123})
-		value2.chain.assertFailed(t)
-		value2.chain.clearFailed()
-
-		value2.NotEqual([]int{123, 456})
-		value2.chain.assertFailed(t)
-		value2.chain.clearFailed()
-
-		value2.NotEqual([]int{456, 123})
-		value2.chain.assertNotFailed(t)
-		value2.chain.clearFailed()
-
-		type S struct {
-			Foo int `json:"foo"`
-		}
-
-		value3.IsEqual([]S{{123}, {456}})
-		value3.chain.assertNotFailed(t)
-		value3.chain.clearFailed()
-
-		value3.IsEqual([]S{{456}, {123}})
-		value3.chain.assertFailed(t)
-		value3.chain.clearFailed()
-
-		value3.NotEqual([]S{{123}, {456}})
-		value3.chain.assertFailed(t)
-		value3.chain.clearFailed()
-
-		value3.NotEqual([]S{{456}, {123}})
-		value3.chain.assertNotFailed(t)
-		value3.chain.clearFailed()
+		value.NotEqual([]S{{456}, {123}})
+		value.chain.assertNotFailed(t)
+		value.chain.clearFailed()
 	})
 
 	t.Run("canonization", func(t *testing.T) {

--- a/match_test.go
+++ b/match_test.go
@@ -167,7 +167,7 @@ func TestMatch_Values(t *testing.T) {
 				{target: []string{""}, fail: true},
 			},
 		},
-		"whole match index 0": {
+		"not empty index 0 only": {
 			submatches: []string{"m0"},
 			expectMatch: []wantMatch{
 				{target: nil, fail: false},

--- a/match_test.go
+++ b/match_test.go
@@ -111,108 +111,100 @@ func TestMatch_Getters(t *testing.T) {
 }
 
 func TestMatch_IsEmpty(t *testing.T) {
-	reporter := newMockReporter(t)
+	cases := map[string]struct {
+		submatch    []string
+		expectEmpty bool
+	}{
+		"string":             {submatch: []string{"m"}, expectEmpty: false},
+		"empty string slice": {submatch: []string{}, expectEmpty: true},
+		"nil":                {submatch: nil, expectEmpty: true},
+	}
 
-	value1 := NewMatch(reporter, []string{"m"}, nil)
-	value2 := NewMatch(reporter, []string{}, nil)
-	value3 := NewMatch(reporter, nil, nil)
+	for name, instance := range cases {
+		t.Run(name, func(t *testing.T) {
+			reporter := newMockReporter(t)
 
-	assert.Equal(t, []string{}, value2.Raw())
-	assert.Equal(t, []string{}, value3.Raw())
+			if instance.expectEmpty {
+				NewMatch(reporter, instance.submatch, nil).IsEmpty().
+					chain.assertNotFailed(t)
 
-	value1.IsEmpty()
-	value1.chain.assertFailed(t)
-	value1.chain.clearFailed()
+				NewMatch(reporter, instance.submatch, nil).NotEmpty().
+					chain.assertFailed(t)
 
-	value1.NotEmpty()
-	value1.chain.assertNotFailed(t)
-	value1.chain.clearFailed()
+				assert.Equal(t, []string{}, NewMatch(reporter, instance.submatch, nil).Raw())
+			} else {
+				NewMatch(reporter, instance.submatch, nil).NotEmpty().
+					chain.assertNotFailed(t)
 
-	value2.IsEmpty()
-	value2.chain.assertNotFailed(t)
-	value2.chain.clearFailed()
-
-	value2.NotEmpty()
-	value2.chain.assertFailed(t)
-	value2.chain.clearFailed()
-
-	value3.IsEmpty()
-	value3.chain.assertNotFailed(t)
-	value3.chain.clearFailed()
-
-	value3.NotEmpty()
-	value3.chain.assertFailed(t)
-	value3.chain.clearFailed()
+				NewMatch(reporter, instance.submatch, nil).IsEmpty().
+					chain.assertFailed(t)
+			}
+		})
+	}
 }
 
 func TestMatch_Values(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
-		reporter := newMockReporter(t)
+	type wantMatch struct {
+		target []string
+		fail   bool
+	}
 
-		value1 := NewMatch(reporter, nil, nil)
-		value2 := NewMatch(reporter, []string{}, nil)
-		value3 := NewMatch(reporter, []string{"m0"}, nil)
+	cases := map[string]struct {
+		submatches  []string
+		expectMatch []wantMatch
+	}{
+		"nil match instance": {
+			submatches: nil,
+			expectMatch: []wantMatch{
+				{target: nil, fail: false},
+				{target: []string{""}, fail: true},
+			},
+		},
+		"empty match instance": {
+			submatches: []string{},
+			expectMatch: []wantMatch{
+				{target: nil, fail: false},
+				{target: []string{""}, fail: true},
+			},
+		},
+		"whole match index 0": {
+			submatches: []string{"m0"},
+			expectMatch: []wantMatch{
+				{target: nil, fail: false},
+				{target: []string{"m0"}, fail: true},
+			},
+		},
+		"not empty": {
+			submatches: []string{"m0", "m1", "m2"},
+			expectMatch: []wantMatch{
+				{target: nil, fail: true},
+				{target: []string{"m1"}, fail: true},
+				{target: []string{"m2", "m1"}, fail: true},
+				{target: []string{"m1", "m2"}, fail: false},
+			},
+		},
+	}
 
-		value1.Values()
-		value1.chain.assertNotFailed(t)
-		value1.chain.clearFailed()
+	for name, instance := range cases {
+		t.Run(name, func(t *testing.T) {
+			reporter := newMockReporter(t)
 
-		value1.Values("")
-		value1.chain.assertFailed(t)
-		value1.chain.clearFailed()
+			for _, match := range instance.expectMatch {
+				if match.fail {
+					NewMatch(reporter, instance.submatches, nil).NotValues(match.target...).
+						chain.assertNotFailed(t)
 
-		value2.Values()
-		value2.chain.assertNotFailed(t)
-		value2.chain.clearFailed()
+					NewMatch(reporter, instance.submatches, nil).Values(match.target...).
+						chain.assertFailed(t)
 
-		value2.Values("")
-		value2.chain.assertFailed(t)
-		value2.chain.clearFailed()
+				} else {
+					NewMatch(reporter, instance.submatches, nil).Values(match.target...).
+						chain.assertNotFailed(t)
 
-		value3.Values()
-		value3.chain.assertNotFailed(t)
-		value3.chain.clearFailed()
-
-		value3.Values("m0")
-		value3.chain.assertFailed(t)
-		value3.chain.clearFailed()
-	})
-
-	t.Run("not empty", func(t *testing.T) {
-		reporter := newMockReporter(t)
-
-		value := NewMatch(reporter, []string{"m0", "m1", "m2"}, nil)
-
-		value.Values("m1", "m2")
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Values("m2", "m1")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.Values("m1")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.Values()
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotValues("m1", "m2")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotValues("m2", "m1")
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotValues("m1")
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotValues()
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-	})
+					NewMatch(reporter, instance.submatches, nil).NotValues(match.target...).
+						chain.assertFailed(t)
+				}
+			}
+		})
+	}
 }

--- a/number_test.go
+++ b/number_test.go
@@ -197,7 +197,7 @@ func TestNumber_IsEqual(t *testing.T) {
 				NewNumber(reporter, instance.number).NotEqual(instance.reference).
 					chain.assertFailed(t)
 
-				assert.Equal(t, float64(instance.number), NewNumber(reporter, instance.number).Raw())
+				assert.Equal(t, instance.reference, int(NewNumber(reporter, instance.number).Raw()))
 			} else {
 				NewNumber(reporter, instance.number).NotEqual(instance.reference).
 					chain.assertNotFailed(t)

--- a/number_test.go
+++ b/number_test.go
@@ -159,101 +159,136 @@ func TestNumber_Getters(t *testing.T) {
 }
 
 func TestNumber_IsEqual(t *testing.T) {
-	reporter := newMockReporter(t)
+	cases := map[string]struct {
+		number      float64
+		reference   interface{}
+		expectEqual bool
+	}{
+		"compare equivalent integers": {
+			number:      1234,
+			reference:   1234,
+			expectEqual: true,
+		},
+		"compare non-equivalent integers": {
+			number:      1234,
+			reference:   4321,
+			expectEqual: false,
+		},
+		"compare NaN to float": {
+			number:      math.NaN(),
+			reference:   1234.5,
+			expectEqual: false,
+		},
+		"compare float to NaN": {
+			number:      1234.5,
+			reference:   math.NaN(),
+			expectEqual: false,
+		},
+	}
 
-	value := NewNumber(reporter, 1234)
+	for name, instance := range cases {
+		t.Run(name, func(t *testing.T) {
+			reporter := newMockReporter(t)
 
-	assert.Equal(t, 1234, int(value.Raw()))
+			if instance.expectEqual {
+				NewNumber(reporter, instance.number).IsEqual(instance.reference).
+					chain.assertNotFailed(t)
 
-	value.IsEqual(1234)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+				NewNumber(reporter, instance.number).NotEqual(instance.reference).
+					chain.assertFailed(t)
 
-	value.IsEqual(4321)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
+				assert.Equal(t, float64(instance.number), NewNumber(reporter, instance.number).Raw())
+			} else {
+				NewNumber(reporter, instance.number).NotEqual(instance.reference).
+					chain.assertNotFailed(t)
 
-	value.NotEqual(4321)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotEqual(1234)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-}
-
-func TestNumber_EqualNaN(t *testing.T) {
-	reporter := newMockReporter(t)
-
-	v1 := NewNumber(reporter, math.NaN())
-	v1.IsEqual(1234.5)
-	v1.chain.assertFailed(t)
-
-	v2 := NewNumber(reporter, 1234.5)
-	v2.IsEqual(math.NaN())
-	v2.chain.assertFailed(t)
-
-	v3 := NewNumber(reporter, math.NaN())
-	v3.InDelta(1234.0, 0.1)
-	v3.chain.assertFailed(t)
-
-	v4 := NewNumber(reporter, 1234.5)
-	v4.InDelta(math.NaN(), 0.1)
-	v4.chain.assertFailed(t)
-
-	v5 := NewNumber(reporter, 1234.5)
-	v5.InDelta(1234.5, math.NaN())
-	v5.chain.assertFailed(t)
-
-	v6 := NewNumber(reporter, math.NaN())
-	v6.NotInDelta(1234.0, 0.1)
-	v6.chain.assertFailed(t)
-
-	v7 := NewNumber(reporter, 1234.5)
-	v7.NotInDelta(math.NaN(), 0.1)
-	v7.chain.assertFailed(t)
-
-	v8 := NewNumber(reporter, 1234.5)
-	v8.NotInDelta(1234.5, math.NaN())
-	v8.chain.assertFailed(t)
+				NewNumber(reporter, instance.number).IsEqual(instance.reference).
+					chain.assertFailed(t)
+			}
+		})
+	}
 }
 
 func TestNumber_InDelta(t *testing.T) {
-	reporter := newMockReporter(t)
+	cases := map[string]struct {
+		number           float64
+		reference        float64
+		delta            float64
+		expectInDelta    bool
+		expectNotInDelta bool
+	}{
+		"larger reference in delta range": {
+			number:           1234.5,
+			reference:        1234.7,
+			delta:            0.3,
+			expectInDelta:    true,
+			expectNotInDelta: false,
+		},
+		"smaller reference in delta range": {
+			number:           1234.5,
+			reference:        1234.3,
+			delta:            0.3,
+			expectInDelta:    true,
+			expectNotInDelta: false,
+		},
+		"larger reference not in delta range": {
+			number:           1234.5,
+			reference:        1234.7,
+			delta:            0.1,
+			expectInDelta:    false,
+			expectNotInDelta: true,
+		},
+		"smaller reference not in delta range": {
+			number:           1234.5,
+			reference:        1234.3,
+			delta:            0.1,
+			expectInDelta:    false,
+			expectNotInDelta: true,
+		},
+		"target is NaN": {
+			number:           math.NaN(),
+			reference:        1234.0,
+			delta:            0.1,
+			expectInDelta:    false,
+			expectNotInDelta: false,
+		},
+		"reference is NaN": {
+			number:           1234.5,
+			reference:        math.NaN(),
+			delta:            0.1,
+			expectInDelta:    false,
+			expectNotInDelta: false,
+		},
+		"delta is NaN": {
+			number:           1234.5,
+			reference:        1234.0,
+			delta:            math.NaN(),
+			expectInDelta:    false,
+			expectNotInDelta: false,
+		},
+	}
 
-	value := NewNumber(reporter, 1234.5)
+	for name, instance := range cases {
+		t.Run(name, func(t *testing.T) {
+			reporter := newMockReporter(t)
 
-	value.InDelta(1234.3, 0.3)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+			if instance.expectInDelta {
+				NewNumber(reporter, instance.number).InDelta(instance.reference, instance.delta).
+					chain.assertNotFailed(t)
+			} else {
+				NewNumber(reporter, instance.number).InDelta(instance.reference, instance.delta).
+					chain.assertFailed(t)
+			}
 
-	value.InDelta(1234.7, 0.3)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.InDelta(1234.3, 0.1)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InDelta(1234.7, 0.1)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInDelta(1234.3, 0.3)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInDelta(1234.7, 0.3)
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInDelta(1234.3, 0.1)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInDelta(1234.7, 0.1)
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+			if instance.expectNotInDelta {
+				NewNumber(reporter, instance.number).NotInDelta(instance.reference, instance.delta).
+					chain.assertNotFailed(t)
+			} else {
+				NewNumber(reporter, instance.number).NotInDelta(instance.reference, instance.delta).
+					chain.assertFailed(t)
+			}
+		})
+	}
 }
 
 func TestNumber_InRange(t *testing.T) {


### PR DESCRIPTION
This is the final PR addressing refactoring tests from #284. This addresses the following tests:
- [x] TestMatch_IsEmpty
- [x] TestMatch_ValuesEmpty
- [x] TestNumber_EqualNaN
- [x] TestArray_IsEqual/types (split into subtests)
- [x] TestWebsocketMessage_CodeAndType
- [x] TestWebsocketMessage_NoContent

I converted all except `TestArray_IsEqual` to table driven style. I only split `TestArray_IsEqual/types` into subtests to address the multiple variable issue.

Also, as noted in the issue, I ended up merging `TestNumber_EqualNaN` into `TestNumber_IsEqual` (and also `TestNumber_InDelta` since half of the test related to InDelta/NotInDelta tests for NaN values). I ended up converting those tests to table-driven format as well.

This is ready for review.