### PR TITLE
Convert some DateTime and Duration tests to be table driven

### DIFF
--- a/datetime_test.go
+++ b/datetime_test.go
@@ -196,117 +196,132 @@ func TestDateTime_IsLesser(t *testing.T) {
 }
 
 func TestDateTime_InRange(t *testing.T) {
-	reporter := newMockReporter(t)
+	cases := map[string]struct {
+		value            time.Time
+		min              time.Time
+		max              time.Time
+		expectInRange    bool
+		expectNotInRange bool
+	}{
+		"value equal to both min and max": {
+			value:            time.Unix(0, 1234),
+			min:              time.Unix(0, 1234),
+			max:              time.Unix(0, 1234),
+			expectInRange:    true,
+			expectNotInRange: false,
+		},
+		"value after min and equal to max": {
+			value:            time.Unix(0, 1234),
+			min:              time.Unix(0, 1234-1),
+			max:              time.Unix(0, 1234),
+			expectInRange:    true,
+			expectNotInRange: false,
+		},
+		"value equal to min and before max": {
+			value:            time.Unix(0, 1234),
+			min:              time.Unix(0, 1234),
+			max:              time.Unix(0, 1234+1),
+			expectInRange:    true,
+			expectNotInRange: false,
+		},
+		"value before range": {
+			value:            time.Unix(0, 1234),
+			min:              time.Unix(0, 1234+1),
+			max:              time.Unix(0, 1234+2),
+			expectInRange:    false,
+			expectNotInRange: true,
+		},
+		"value after range": {
+			value:            time.Unix(0, 1234),
+			min:              time.Unix(0, 1234-2),
+			max:              time.Unix(0, 1234-1),
+			expectInRange:    false,
+			expectNotInRange: true,
+		},
+		"invalid range": {
+			value:            time.Unix(0, 1234),
+			min:              time.Unix(0, 1234+1),
+			max:              time.Unix(0, 1234-1),
+			expectInRange:    false,
+			expectNotInRange: true,
+		},
+	}
 
-	value := NewDateTime(reporter, time.Unix(0, 1234))
+	for name, instance := range cases {
+		t.Run(name, func(t *testing.T) {
+			reporter := newMockReporter(t)
 
-	value.InRange(time.Unix(0, 1234), time.Unix(0, 1234))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInRange(time.Unix(0, 1234), time.Unix(0, 1234))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InRange(time.Unix(0, 1234-1), time.Unix(0, 1234))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInRange(time.Unix(0, 1234-1), time.Unix(0, 1234))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InRange(time.Unix(0, 1234), time.Unix(0, 1234+1))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInRange(time.Unix(0, 1234), time.Unix(0, 1234+1))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InRange(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInRange(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.InRange(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInRange(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.InRange(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInRange(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+			if instance.expectInRange {
+				NewDateTime(reporter, instance.value).
+					InRange(instance.min, instance.max).
+					chain.assertNotFailed(t)
+			} else {
+				NewDateTime(reporter, instance.value).
+					InRange(instance.min, instance.max).
+					chain.assertFailed(t)
+			}
+			if instance.expectNotInRange {
+				NewDateTime(reporter, instance.value).
+					NotInRange(instance.min, instance.max).
+					chain.assertNotFailed(t)
+			} else {
+				NewDateTime(reporter, instance.value).
+					NotInRange(instance.min, instance.max).
+					chain.assertFailed(t)
+			}
+		})
+	}
 }
 
 func TestDateTime_InList(t *testing.T) {
-	reporter := newMockReporter(t)
+	cases := map[string]struct {
+		value           time.Time
+		list            []time.Time
+		expectInList    bool
+		expectNotInList bool
+	}{
+		"empty list": {
+			value:           time.Unix(0, 1234),
+			list:            []time.Time{},
+			expectInList:    false,
+			expectNotInList: false,
+		},
+		"value present in list": {
+			value:           time.Unix(0, 1234),
+			list:            []time.Time{time.Unix(0, 1234), time.Unix(0, 1234+1)},
+			expectInList:    true,
+			expectNotInList: false,
+		},
+		"value not present in list": {
+			value:           time.Unix(0, 1234),
+			list:            []time.Time{time.Unix(0, 1234-1), time.Unix(0, 1234+1)},
+			expectInList:    false,
+			expectNotInList: true,
+		},
+	}
 
-	value := NewDateTime(reporter, time.Unix(0, 1234))
+	for name, instance := range cases {
+		t.Run(name, func(t *testing.T) {
+			reporter := newMockReporter(t)
 
-	value.InList()
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList()
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InList(time.Unix(0, 1234), time.Unix(0, 1234))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList(time.Unix(0, 1234), time.Unix(0, 1234))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InList(time.Unix(0, 1234-1), time.Unix(0, 1234))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList(time.Unix(0, 1234-1), time.Unix(0, 1234))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InList(time.Unix(0, 1234), time.Unix(0, 1234+1))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList(time.Unix(0, 1234), time.Unix(0, 1234+1))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.InList(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.InList(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
-
-	value.InList(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
-	value.chain.assertFailed(t)
-	value.chain.clearFailed()
-
-	value.NotInList(time.Unix(0, 1234+1), time.Unix(0, 1234-1))
-	value.chain.assertNotFailed(t)
-	value.chain.clearFailed()
+			if instance.expectInList {
+				NewDateTime(reporter, instance.value).
+					InList(instance.list...).
+					chain.assertNotFailed(t)
+			} else {
+				NewDateTime(reporter, instance.value).
+					InList(instance.list...).
+					chain.assertFailed(t)
+			}
+			if instance.expectNotInList {
+				NewDateTime(reporter, instance.value).
+					NotInList(instance.list...).
+					chain.assertNotFailed(t)
+			} else {
+				NewDateTime(reporter, instance.value).
+					NotInList(instance.list...).
+					chain.assertFailed(t)
+			}
+		})
+	}
 }

--- a/datetime_test.go
+++ b/datetime_test.go
@@ -196,49 +196,56 @@ func TestDateTime_IsLesser(t *testing.T) {
 }
 
 func TestDateTime_InRange(t *testing.T) {
-	cases := map[string]struct {
+	cases := []struct {
+		name             string
 		value            time.Time
 		min              time.Time
 		max              time.Time
 		expectInRange    bool
 		expectNotInRange bool
 	}{
-		"value equal to both min and max": {
+		{
+			name:             "value equal to both min and max",
 			value:            time.Unix(0, 1234),
 			min:              time.Unix(0, 1234),
 			max:              time.Unix(0, 1234),
 			expectInRange:    true,
 			expectNotInRange: false,
 		},
-		"value after min and equal to max": {
+		{
+			name:             "value after min and equal to max",
 			value:            time.Unix(0, 1234),
 			min:              time.Unix(0, 1234-1),
 			max:              time.Unix(0, 1234),
 			expectInRange:    true,
 			expectNotInRange: false,
 		},
-		"value equal to min and before max": {
+		{
+			name:             "value equal to min and before max",
 			value:            time.Unix(0, 1234),
 			min:              time.Unix(0, 1234),
 			max:              time.Unix(0, 1234+1),
 			expectInRange:    true,
 			expectNotInRange: false,
 		},
-		"value before range": {
+		{
+			name:             "value before range",
 			value:            time.Unix(0, 1234),
 			min:              time.Unix(0, 1234+1),
 			max:              time.Unix(0, 1234+2),
 			expectInRange:    false,
 			expectNotInRange: true,
 		},
-		"value after range": {
+		{
+			name:             "value after range",
 			value:            time.Unix(0, 1234),
 			min:              time.Unix(0, 1234-2),
 			max:              time.Unix(0, 1234-1),
 			expectInRange:    false,
 			expectNotInRange: true,
 		},
-		"invalid range": {
+		{
+			name:             "invalid range",
 			value:            time.Unix(0, 1234),
 			min:              time.Unix(0, 1234+1),
 			max:              time.Unix(0, 1234-1),
@@ -247,26 +254,26 @@ func TestDateTime_InRange(t *testing.T) {
 		},
 	}
 
-	for name, instance := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			reporter := newMockReporter(t)
 
-			if instance.expectInRange {
-				NewDateTime(reporter, instance.value).
-					InRange(instance.min, instance.max).
+			if tc.expectInRange {
+				NewDateTime(reporter, tc.value).
+					InRange(tc.min, tc.max).
 					chain.assertNotFailed(t)
 			} else {
-				NewDateTime(reporter, instance.value).
-					InRange(instance.min, instance.max).
+				NewDateTime(reporter, tc.value).
+					InRange(tc.min, tc.max).
 					chain.assertFailed(t)
 			}
-			if instance.expectNotInRange {
-				NewDateTime(reporter, instance.value).
-					NotInRange(instance.min, instance.max).
+			if tc.expectNotInRange {
+				NewDateTime(reporter, tc.value).
+					NotInRange(tc.min, tc.max).
 					chain.assertNotFailed(t)
 			} else {
-				NewDateTime(reporter, instance.value).
-					NotInRange(instance.min, instance.max).
+				NewDateTime(reporter, tc.value).
+					NotInRange(tc.min, tc.max).
 					chain.assertFailed(t)
 			}
 		})
@@ -274,25 +281,29 @@ func TestDateTime_InRange(t *testing.T) {
 }
 
 func TestDateTime_InList(t *testing.T) {
-	cases := map[string]struct {
+	cases := []struct {
+		name            string
 		value           time.Time
 		list            []time.Time
 		expectInList    bool
 		expectNotInList bool
 	}{
-		"empty list": {
+		{
+			name:            "empty list",
 			value:           time.Unix(0, 1234),
 			list:            []time.Time{},
 			expectInList:    false,
 			expectNotInList: false,
 		},
-		"value present in list": {
+		{
+			name:            "value present in list",
 			value:           time.Unix(0, 1234),
 			list:            []time.Time{time.Unix(0, 1234), time.Unix(0, 1234+1)},
 			expectInList:    true,
 			expectNotInList: false,
 		},
-		"value not present in list": {
+		{
+			name:            "value not present in list",
 			value:           time.Unix(0, 1234),
 			list:            []time.Time{time.Unix(0, 1234-1), time.Unix(0, 1234+1)},
 			expectInList:    false,
@@ -300,26 +311,26 @@ func TestDateTime_InList(t *testing.T) {
 		},
 	}
 
-	for name, instance := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			reporter := newMockReporter(t)
 
-			if instance.expectInList {
-				NewDateTime(reporter, instance.value).
-					InList(instance.list...).
+			if tc.expectInList {
+				NewDateTime(reporter, tc.value).
+					InList(tc.list...).
 					chain.assertNotFailed(t)
 			} else {
-				NewDateTime(reporter, instance.value).
-					InList(instance.list...).
+				NewDateTime(reporter, tc.value).
+					InList(tc.list...).
 					chain.assertFailed(t)
 			}
-			if instance.expectNotInList {
-				NewDateTime(reporter, instance.value).
-					NotInList(instance.list...).
+			if tc.expectNotInList {
+				NewDateTime(reporter, tc.value).
+					NotInList(tc.list...).
 					chain.assertNotFailed(t)
 			} else {
-				NewDateTime(reporter, instance.value).
-					NotInList(instance.list...).
+				NewDateTime(reporter, tc.value).
+					NotInList(tc.list...).
 					chain.assertFailed(t)
 			}
 		})

--- a/duration_test.go
+++ b/duration_test.go
@@ -252,11 +252,6 @@ func TestDuration_InRange(t *testing.T) {
 }
 
 func TestDuration_InList(t *testing.T) {
-	t.Run("value is not present", func(t *testing.T) {
-		newDuration(newMockChain(t), nil).InList(time.Second).chain.assertFailed(t)
-		newDuration(newMockChain(t), nil).NotInList(time.Second).chain.assertFailed(t)
-	})
-
 	cases := map[string]struct {
 		value           time.Duration
 		list            []time.Duration

--- a/duration_test.go
+++ b/duration_test.go
@@ -174,49 +174,56 @@ func TestDuration_IsLesser(t *testing.T) {
 }
 
 func TestDuration_InRange(t *testing.T) {
-	cases := map[string]struct {
+	cases := []struct {
+		name             string
 		value            time.Duration
 		min              time.Duration
 		max              time.Duration
 		expectInRange    bool
 		expectNotInRange bool
 	}{
-		"value equal to both min and max": {
+		{
+			name:             "value equal to both min and max",
 			value:            time.Second,
 			min:              time.Second,
 			max:              time.Second,
 			expectInRange:    true,
 			expectNotInRange: false,
 		},
-		"value greater than min and equal to max": {
+		{
+			name:             "value greater than min and equal to max",
 			value:            time.Second,
 			min:              time.Second - 1,
 			max:              time.Second,
 			expectInRange:    true,
 			expectNotInRange: false,
 		},
-		"value equal to min and smaller than max": {
+		{
+			name:             "value equal to min and smaller than max",
 			value:            time.Second,
 			min:              time.Second,
 			max:              time.Second + 1,
 			expectInRange:    true,
 			expectNotInRange: false,
 		},
-		"value smaller than min": {
+		{
+			name:             "value smaller than min",
 			value:            time.Second,
 			min:              time.Second + 1,
 			max:              time.Second + 2,
 			expectInRange:    false,
 			expectNotInRange: true,
 		},
-		"value greater than max": {
+		{
+			name:             "value greater than max",
 			value:            time.Second,
 			min:              time.Second - 2,
 			max:              time.Second - 1,
 			expectInRange:    false,
 			expectNotInRange: true,
 		},
-		"min smaller than max": {
+		{
+			name:             "min smaller than max",
 			value:            time.Second,
 			min:              time.Second + 1,
 			max:              time.Second - 1,
@@ -225,26 +232,26 @@ func TestDuration_InRange(t *testing.T) {
 		},
 	}
 
-	for name, instance := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			reporter := newMockReporter(t)
 
-			if instance.expectInRange {
-				NewDuration(reporter, instance.value).
-					InRange(instance.min, instance.max).
+			if tc.expectInRange {
+				NewDuration(reporter, tc.value).
+					InRange(tc.min, tc.max).
 					chain.assertNotFailed(t)
 			} else {
-				NewDuration(reporter, instance.value).
-					InRange(instance.min, instance.max).
+				NewDuration(reporter, tc.value).
+					InRange(tc.min, tc.max).
 					chain.assertFailed(t)
 			}
-			if instance.expectNotInRange {
-				NewDuration(reporter, instance.value).
-					NotInRange(instance.min, instance.max).
+			if tc.expectNotInRange {
+				NewDuration(reporter, tc.value).
+					NotInRange(tc.min, tc.max).
 					chain.assertNotFailed(t)
 			} else {
-				NewDuration(reporter, instance.value).
-					NotInRange(instance.min, instance.max).
+				NewDuration(reporter, tc.value).
+					NotInRange(tc.min, tc.max).
 					chain.assertFailed(t)
 			}
 		})
@@ -252,25 +259,29 @@ func TestDuration_InRange(t *testing.T) {
 }
 
 func TestDuration_InList(t *testing.T) {
-	cases := map[string]struct {
+	cases := []struct {
+		name            string
 		value           time.Duration
 		list            []time.Duration
 		expectInList    bool
 		expectNotInList bool
 	}{
-		"empty list": {
+		{
+			name:            "empty list",
 			value:           time.Second,
 			list:            []time.Duration{},
 			expectInList:    false,
 			expectNotInList: false,
 		},
-		"value present in list": {
+		{
+			name:            "value present in list",
 			value:           time.Second,
 			list:            []time.Duration{time.Second, time.Minute},
 			expectInList:    true,
 			expectNotInList: false,
 		},
-		"value not present in list": {
+		{
+			name:            "value not present in list",
 			value:           time.Second,
 			list:            []time.Duration{time.Second - 1, time.Second + 1},
 			expectInList:    false,
@@ -278,26 +289,26 @@ func TestDuration_InList(t *testing.T) {
 		},
 	}
 
-	for name, instance := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			reporter := newMockReporter(t)
 
-			if instance.expectInList {
-				NewDuration(reporter, instance.value).
-					InList(instance.list...).
+			if tc.expectInList {
+				NewDuration(reporter, tc.value).
+					InList(tc.list...).
 					chain.assertNotFailed(t)
 			} else {
-				NewDuration(reporter, instance.value).
-					InList(instance.list...).
+				NewDuration(reporter, tc.value).
+					InList(tc.list...).
 					chain.assertFailed(t)
 			}
-			if instance.expectNotInList {
-				NewDuration(reporter, instance.value).
-					NotInList(instance.list...).
+			if tc.expectNotInList {
+				NewDuration(reporter, tc.value).
+					NotInList(tc.list...).
 					chain.assertNotFailed(t)
 			} else {
-				NewDuration(reporter, instance.value).
-					NotInList(instance.list...).
+				NewDuration(reporter, tc.value).
+					NotInList(tc.list...).
 					chain.assertFailed(t)
 			}
 		})


### PR DESCRIPTION
Fixes #310 

I've created the PR, but I'm not sure about 2 things:
- How to handle the test cases below in table driven style as they use different function to create the object than other test cases.
```
newDuration(newMockChain(t), nil).InList(time.Second).chain.assertFailed(t)
newDuration(newMockChain(t), nil).NotInList(time.Second).chain.assertFailed(t)
```
- I removed some test cases for InList tests, as I believe they were copied from InRange test cases and didn't test any edge cases, e.g.:
```
value.InList(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
value.chain.assertFailed(t)
value.chain.clearFailed()

value.NotInList(time.Unix(0, 1234+1), time.Unix(0, 1234+2))
value.chain.assertNotFailed(t)
value.chain.clearFailed()

value.InList(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
value.chain.assertFailed(t)
value.chain.clearFailed()

value.NotInList(time.Unix(0, 1234-2), time.Unix(0, 1234-1))
value.chain.assertNotFailed(t)
value.chain.clearFailed()
```

If any of these should be changed please let me know.