### PR TITLE
Convert some number tests to be table driven

### DIFF
--- a/number_test.go
+++ b/number_test.go
@@ -160,51 +160,60 @@ func TestNumber_Getters(t *testing.T) {
 
 func TestNumber_IsEqual(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		cases := map[string]struct {
-			number      float64
-			reference   interface{}
-			expectEqual bool
+		cases := []struct {
+			name      string
+			number    float64
+			reference interface{}
+			isEqual   bool
 		}{
-			"compare equivalent integers": {
-				number:      1234,
-				reference:   1234,
-				expectEqual: true,
+			{
+				name:      "compare equivalent integers",
+				number:    1234,
+				reference: 1234,
+				isEqual:   true,
 			},
-			"compare non-equivalent integers": {
-				number:      1234,
-				reference:   4321,
-				expectEqual: false,
+			{
+				name:      "compare non-equivalent integers",
+				number:    1234,
+				reference: 4321,
+				isEqual:   false,
 			},
-			"compare NaN to float": {
-				number:      math.NaN(),
-				reference:   1234.5,
-				expectEqual: false,
+			{
+				name:      "compare NaN to float",
+				number:    math.NaN(),
+				reference: 1234.5,
+				isEqual:   false,
 			},
-			"compare float to NaN": {
-				number:      1234.5,
-				reference:   math.NaN(),
-				expectEqual: false,
+			{
+				name:      "compare float to NaN",
+				number:    1234.5,
+				reference: math.NaN(),
+				isEqual:   false,
 			},
 		}
 
-		for name, instance := range cases {
-			t.Run(name, func(t *testing.T) {
+		for _, instance := range cases {
+			t.Run(instance.name, func(t *testing.T) {
 				reporter := newMockReporter(t)
 
-				if instance.expectEqual {
-					NewNumber(reporter, instance.number).IsEqual(instance.reference).
+				if instance.isEqual {
+					NewNumber(reporter, instance.number).
+						IsEqual(instance.reference).
 						chain.assertNotFailed(t)
 
-					NewNumber(reporter, instance.number).NotEqual(instance.reference).
+					NewNumber(reporter, instance.number).
+						NotEqual(instance.reference).
 						chain.assertFailed(t)
 
 					assert.Equal(t, instance.reference,
 						int(NewNumber(reporter, instance.number).Raw()))
 				} else {
-					NewNumber(reporter, instance.number).NotEqual(instance.reference).
+					NewNumber(reporter, instance.number).
+						NotEqual(instance.reference).
 						chain.assertNotFailed(t)
 
-					NewNumber(reporter, instance.number).IsEqual(instance.reference).
+					NewNumber(reporter, instance.number).
+						IsEqual(instance.reference).
 						chain.assertFailed(t)
 				}
 			})
@@ -214,104 +223,102 @@ func TestNumber_IsEqual(t *testing.T) {
 	t.Run("canonization", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).IsEqual(int64(1234)).
+			chain.assertNotFailed(t)
 
-		value.IsEqual(int64(1234))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).IsEqual(float32(1234)).
+			chain.assertNotFailed(t)
 
-		value.IsEqual(float32(1234))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).NotEqual(int64(4321)).
+			chain.assertNotFailed(t)
 
-		value.NotEqual(int64(4321))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqual(float32(4321))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).NotEqual(float32(4321)).
+			chain.assertNotFailed(t)
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).IsEqual("NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.IsEqual("NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotEqual("NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).NotEqual("NOT NUMBER").
+			chain.assertFailed(t)
 	})
 }
 
 func TestNumber_InDelta(t *testing.T) {
-	cases := map[string]struct {
-		number           float64
-		reference        float64
-		delta            float64
-		expectInDelta    bool
-		expectNotInDelta bool
+	cases := []struct {
+		name         string
+		number       float64
+		reference    float64
+		delta        float64
+		isInDelta    bool
+		isNotInDelta bool
 	}{
-		"larger reference in delta range": {
-			number:           1234.5,
-			reference:        1234.7,
-			delta:            0.3,
-			expectInDelta:    true,
-			expectNotInDelta: false,
+		{
+			name:         "larger reference in delta range",
+			number:       1234.5,
+			reference:    1234.7,
+			delta:        0.3,
+			isInDelta:    true,
+			isNotInDelta: false,
 		},
-		"smaller reference in delta range": {
-			number:           1234.5,
-			reference:        1234.3,
-			delta:            0.3,
-			expectInDelta:    true,
-			expectNotInDelta: false,
+		{
+			name:         "smaller reference in delta range",
+			number:       1234.5,
+			reference:    1234.3,
+			delta:        0.3,
+			isInDelta:    true,
+			isNotInDelta: false,
 		},
-		"larger reference not in delta range": {
-			number:           1234.5,
-			reference:        1234.7,
-			delta:            0.1,
-			expectInDelta:    false,
-			expectNotInDelta: true,
+		{
+			name:         "larger reference not in delta range",
+			number:       1234.5,
+			reference:    1234.7,
+			delta:        0.1,
+			isInDelta:    false,
+			isNotInDelta: true,
 		},
-		"smaller reference not in delta range": {
-			number:           1234.5,
-			reference:        1234.3,
-			delta:            0.1,
-			expectInDelta:    false,
-			expectNotInDelta: true,
+		{
+			name:         "smaller reference not in delta range",
+			number:       1234.5,
+			reference:    1234.3,
+			delta:        0.1,
+			isInDelta:    false,
+			isNotInDelta: true,
 		},
-		"target is NaN": {
-			number:           math.NaN(),
-			reference:        1234.0,
-			delta:            0.1,
-			expectInDelta:    false,
-			expectNotInDelta: false,
+		{
+			name:         "target is NaN",
+			number:       math.NaN(),
+			reference:    1234.0,
+			delta:        0.1,
+			isInDelta:    false,
+			isNotInDelta: false,
 		},
-		"reference is NaN": {
-			number:           1234.5,
-			reference:        math.NaN(),
-			delta:            0.1,
-			expectInDelta:    false,
-			expectNotInDelta: false,
+		{
+			name:         "reference is NaN",
+			number:       1234.5,
+			reference:    math.NaN(),
+			delta:        0.1,
+			isInDelta:    false,
+			isNotInDelta: false,
 		},
-		"delta is NaN": {
-			number:           1234.5,
-			reference:        1234.0,
-			delta:            math.NaN(),
-			expectInDelta:    false,
-			expectNotInDelta: false,
+		{
+			name:         "delta is NaN",
+			number:       1234.5,
+			reference:    1234.0,
+			delta:        math.NaN(),
+			isInDelta:    false,
+			isNotInDelta: false,
 		},
 	}
 
-	for name, instance := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, instance := range cases {
+		t.Run(instance.name, func(t *testing.T) {
 			reporter := newMockReporter(t)
 
-			if instance.expectInDelta {
+			if instance.isInDelta {
 				NewNumber(reporter, instance.number).
 					InDelta(instance.reference, instance.delta).
 					chain.assertNotFailed(t)
@@ -321,7 +328,7 @@ func TestNumber_InDelta(t *testing.T) {
 					chain.assertFailed(t)
 			}
 
-			if instance.expectNotInDelta {
+			if instance.isNotInDelta {
 				NewNumber(reporter, instance.number).
 					NotInDelta(instance.reference, instance.delta).
 					chain.assertNotFailed(t)
@@ -336,322 +343,398 @@ func TestNumber_InDelta(t *testing.T) {
 
 func TestNumber_InRange(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
+		cases := []struct {
+			name         string
+			number       float64
+			min          interface{}
+			max          interface{}
+			isInRange    bool
+			isNotInRange bool
+		}{
+			{
+				name:         "range includes only number",
+				number:       1234,
+				min:          1234,
+				max:          1234,
+				isInRange:    true,
+				isNotInRange: false,
+			},
+			{
+				name:         "range includes number and below",
+				number:       1234,
+				min:          1234 - 1,
+				max:          1234,
+				isInRange:    true,
+				isNotInRange: false,
+			},
+			{
+				name:         "range includes number and above",
+				number:       1234,
+				min:          1234,
+				max:          1234 + 1,
+				isInRange:    true,
+				isNotInRange: false,
+			},
+			{
+				name:         "range is above number",
+				number:       1234,
+				min:          1234 + 1,
+				max:          1234 + 2,
+				isInRange:    false,
+				isNotInRange: true,
+			},
+			{
+				name:         "range is below number",
+				number:       1234,
+				min:          1234 - 2,
+				max:          1234 - 1,
+				isInRange:    false,
+				isNotInRange: true,
+			},
+			{
+				name:         "range min is larger than max",
+				number:       1234,
+				min:          1234 + 1,
+				max:          1234 - 1,
+				isInRange:    false,
+				isNotInRange: true,
+			},
+		}
 
-		value := NewNumber(reporter, 1234)
+		for _, instance := range cases {
+			t.Run(instance.name, func(t *testing.T) {
+				reporter := newMockReporter(t)
 
-		value.InRange(1234, 1234)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+				if instance.isInRange {
+					NewNumber(reporter, instance.number).
+						InRange(instance.min, instance.max).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						InRange(instance.min, instance.max).
+						chain.assertFailed(t)
+				}
 
-		value.NotInRange(1234, 1234)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.InRange(1234-1, 1234)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange(1234-1, 1234)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.InRange(1234, 1234+1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange(1234, 1234+1)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.InRange(1234+1, 1234+2)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange(1234+1, 1234+2)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.InRange(1234-2, 1234-1)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange(1234-2, 1234-1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.InRange(1234+1, 1234-1)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange(1234+1, 1234-1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+				if instance.isNotInRange {
+					NewNumber(reporter, instance.number).
+						NotInRange(instance.min, instance.max).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						NotInRange(instance.min, instance.max).
+						chain.assertFailed(t)
+				}
+			})
+		}
 	})
 
 	t.Run("canonization", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).InRange(int64(1233), float32(1235)).
+			chain.assertNotFailed(t)
 
-		value.InRange(int64(1233), float32(1235))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).NotInRange(int64(1233), float32(1235)).
+			chain.assertFailed(t)
 
-		value.NotInRange(int64(1233), float32(1235))
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).InRange(1235, 1236).
+			chain.assertFailed(t)
 
-		value.InRange(1235, 1236)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange(1235, 1236)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
+		NewNumber(reporter, 1234).NotInRange(1235, 1236).
+			chain.assertNotFailed(t)
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).InRange(int64(1233), "NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.InRange(int64(1233), "NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).NotInRange(int64(1233), "NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.NotInRange(int64(1233), "NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).InRange("NOT NUMBER", float32(1235)).
+			chain.assertFailed(t)
 
-		value.InRange("NOT NUMBER", float32(1235))
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInRange("NOT NUMBER", float32(1235))
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).NotInRange("NOT NUMBER", float32(1235)).
+			chain.assertFailed(t)
 	})
 }
 
 func TestNumber_InList(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
+		cases := []struct {
+			name        string
+			number      float64
+			list        []interface{}
+			isInList    bool
+			isNotInList bool
+		}{
+			{
+				name:        "no list",
+				number:      1234,
+				list:        nil,
+				isInList:    false,
+				isNotInList: false,
+			},
+			{
+				name:        "in integer list",
+				number:      1234,
+				list:        []interface{}{1234, 4567},
+				isInList:    true,
+				isNotInList: false,
+			},
+			{
+				name:        "in float list",
+				number:      1234,
+				list:        []interface{}{1234.00, 4567.00},
+				isInList:    true,
+				isNotInList: false,
+			},
+			{
+				name:        "not in float list",
+				number:      1234,
+				list:        []interface{}{4567.00, 1234.01},
+				isInList:    false,
+				isNotInList: true,
+			},
+		}
 
-		value := NewNumber(reporter, 1234)
+		for _, instance := range cases {
+			t.Run(instance.name, func(t *testing.T) {
+				reporter := newMockReporter(t)
 
-		value.InList()
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+				if instance.isInList {
+					NewNumber(reporter, instance.number).
+						InList(instance.list...).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						InList(instance.list...).
+						chain.assertFailed(t)
+				}
 
-		value.NotInList()
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.InList(1234, 4567)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInList(1234, 4567)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.InList(1234.00, 4567.00)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInList(1234.00, 4567.00)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.InList(4567.00, 1234.01)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInList(4567.00, 1234.01)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+				if instance.isNotInList {
+					NewNumber(reporter, instance.number).
+						NotInList(instance.list...).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						NotInList(instance.list...).
+						chain.assertFailed(t)
+				}
+			})
+		}
 	})
 
 	t.Run("canonization", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 111)
+		NewNumber(reporter, 111).InList(int64(111), float32(222)).
+			chain.assertNotFailed(t)
 
-		value.InList(int64(111), float32(222))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).NotInList(int64(111), float32(222)).
+			chain.assertFailed(t)
 
-		value.NotInList(int64(111), float32(222))
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).InList(float32(111), int64(222)).
+			chain.assertNotFailed(t)
 
-		value.InList(float32(111), int64(222))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).NotInList(float32(111), int64(222)).
+			chain.assertFailed(t)
 
-		value.NotInList(float32(111), int64(222))
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).InList(222, 333).
+			chain.assertFailed(t)
 
-		value.InList(222, 333)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInList(222, 333)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).NotInList(222, 333).
+			chain.assertNotFailed(t)
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 111)
+		NewNumber(reporter, 111).InList(222, "NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.InList(222, "NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).NotInList(222, "NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.NotInList(222, "NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).InList(111, "NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.InList(111, "NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.NotInList(111, "NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 111).NotInList(111, "NOT NUMBER").
+			chain.assertFailed(t)
 	})
 }
 
 func TestNumber_IsGreater(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
+		cases := []struct {
+			name      string
+			number    float64
+			reference interface{}
+			isGt      bool
+			isGe      bool
+		}{
+			{
+				name:      "number is lesser",
+				number:    1234,
+				reference: 1234 + 1,
+				isGt:      false,
+				isGe:      false,
+			},
+			{
+				name:      "number is equal",
+				number:    1234,
+				reference: 1234,
+				isGt:      false,
+				isGe:      true,
+			},
+			{
+				name:      "number is greater",
+				number:    1234,
+				reference: 1234 - 1,
+				isGt:      true,
+				isGe:      true,
+			},
+		}
 
-		value := NewNumber(reporter, 1234)
+		for _, instance := range cases {
+			t.Run(instance.name, func(t *testing.T) {
+				reporter := newMockReporter(t)
 
-		value.Gt(1234 - 1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+				if instance.isGt {
+					NewNumber(reporter, instance.number).
+						Gt(instance.reference).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						Gt(instance.reference).
+						chain.assertFailed(t)
+				}
 
-		value.Gt(1234)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.Ge(1234 - 1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Ge(1234)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Ge(1234 + 1)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+				if instance.isGe {
+					NewNumber(reporter, instance.number).
+						Ge(instance.reference).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						Ge(instance.reference).
+						chain.assertFailed(t)
+				}
+			})
+		}
 	})
 
 	t.Run("canonization", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).Gt(int64(1233)).
+			chain.assertNotFailed(t)
 
-		value.Gt(int64(1233))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Gt(float32(1233)).
+			chain.assertNotFailed(t)
 
-		value.Gt(float32(1233))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Ge(int64(1233)).
+			chain.assertNotFailed(t)
 
-		value.Ge(int64(1233))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Ge(float32(1233))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Ge(float32(1233)).
+			chain.assertNotFailed(t)
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).Gt("NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.Gt("NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.Ge("NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Ge("NOT NUMBER").
+			chain.assertFailed(t)
 	})
 }
 
 func TestNumber_IsLesser(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		reporter := newMockReporter(t)
+		cases := []struct {
+			name      string
+			number    float64
+			reference interface{}
+			isLt      bool
+			isLe      bool
+		}{
+			{
+				name:      "number is lesser",
+				number:    1234,
+				reference: 1234 + 1,
+				isLt:      true,
+				isLe:      true,
+			},
+			{
+				name:      "number is equal",
+				number:    1234,
+				reference: 1234,
+				isLt:      false,
+				isLe:      true,
+			},
+			{
+				name:      "number is greater",
+				number:    1234,
+				reference: 1234 - 1,
+				isLt:      false,
+				isLe:      false,
+			},
+		}
 
-		value := NewNumber(reporter, 1234)
+		for _, instance := range cases {
+			t.Run(instance.name, func(t *testing.T) {
+				reporter := newMockReporter(t)
 
-		value.Lt(1234 + 1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+				if instance.isLt {
+					NewNumber(reporter, instance.number).
+						Lt(instance.reference).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						Lt(instance.reference).
+						chain.assertFailed(t)
+				}
 
-		value.Lt(1234)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.Le(1234 + 1)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Le(1234)
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Le(1234 - 1)
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+				if instance.isLe {
+					NewNumber(reporter, instance.number).
+						Le(instance.reference).
+						chain.assertNotFailed(t)
+				} else {
+					NewNumber(reporter, instance.number).
+						Le(instance.reference).
+						chain.assertFailed(t)
+				}
+			})
+		}
 	})
 
 	t.Run("canonization", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).Lt(int64(1235)).
+			chain.assertNotFailed(t)
 
-		value.Lt(int64(1235))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Lt(float32(1235)).
+			chain.assertNotFailed(t)
 
-		value.Lt(float32(1235))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Le(int64(1235)).
+			chain.assertNotFailed(t)
 
-		value.Le(int64(1235))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
-
-		value.Le(float32(1235))
-		value.chain.assertNotFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Le(float32(1235)).
+			chain.assertNotFailed(t)
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		value := NewNumber(reporter, 1234)
+		NewNumber(reporter, 1234).Lt("NOT NUMBER").
+			chain.assertFailed(t)
 
-		value.Lt("NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
-
-		value.Le("NOT NUMBER")
-		value.chain.assertFailed(t)
-		value.chain.clearFailed()
+		NewNumber(reporter, 1234).Le("NOT NUMBER").
+			chain.assertFailed(t)
 	})
 }
 

--- a/number_test.go
+++ b/number_test.go
@@ -429,19 +429,47 @@ func TestNumber_InRange(t *testing.T) {
 	})
 
 	t.Run("canonization", func(t *testing.T) {
+		cases := []struct {
+			number    float64
+			min       interface{}
+			max       interface{}
+			isInRange bool
+		}{
+			{
+				number:    1234,
+				min:       int64(1233),
+				max:       float32(1235),
+				isInRange: true,
+			},
+			{
+				number:    1234,
+				min:       1235,
+				max:       1236,
+				isInRange: false,
+			},
+		}
+
 		reporter := newMockReporter(t)
 
-		NewNumber(reporter, 1234).InRange(int64(1233), float32(1235)).
-			chain.assertNotFailed(t)
+		for _, instance := range cases {
+			if instance.isInRange {
+				NewNumber(reporter, instance.number).
+					InRange(instance.min, instance.max).
+					chain.assertNotFailed(t)
 
-		NewNumber(reporter, 1234).NotInRange(int64(1233), float32(1235)).
-			chain.assertFailed(t)
+				NewNumber(reporter, instance.number).
+					NotInRange(instance.min, instance.max).
+					chain.assertFailed(t)
+			} else {
+				NewNumber(reporter, instance.number).
+					NotInRange(instance.min, instance.max).
+					chain.assertNotFailed(t)
 
-		NewNumber(reporter, 1234).InRange(1235, 1236).
-			chain.assertFailed(t)
-
-		NewNumber(reporter, 1234).NotInRange(1235, 1236).
-			chain.assertNotFailed(t)
+				NewNumber(reporter, instance.number).
+					InRange(instance.min, instance.max).
+					chain.assertFailed(t)
+			}
+		}
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {
@@ -528,25 +556,49 @@ func TestNumber_InList(t *testing.T) {
 	})
 
 	t.Run("canonization", func(t *testing.T) {
+		cases := []struct {
+			number   float64
+			list     []interface{}
+			isInList bool
+		}{
+			{
+				number:   111,
+				list:     []interface{}{int64(111), float32(222)},
+				isInList: true,
+			},
+			{
+				number:   111,
+				list:     []interface{}{float32(111), int64(222)},
+				isInList: true,
+			},
+			{
+				number:   111,
+				list:     []interface{}{222, 333},
+				isInList: false,
+			},
+		}
+
 		reporter := newMockReporter(t)
 
-		NewNumber(reporter, 111).InList(int64(111), float32(222)).
-			chain.assertNotFailed(t)
+		for _, instance := range cases {
+			if instance.isInList {
+				NewNumber(reporter, instance.number).
+					InList(instance.list...).
+					chain.assertNotFailed(t)
 
-		NewNumber(reporter, 111).NotInList(int64(111), float32(222)).
-			chain.assertFailed(t)
+				NewNumber(reporter, instance.number).
+					NotInList(instance.list...).
+					chain.assertFailed(t)
+			} else {
+				NewNumber(reporter, instance.number).
+					NotInList(instance.list...).
+					chain.assertNotFailed(t)
 
-		NewNumber(reporter, 111).InList(float32(111), int64(222)).
-			chain.assertNotFailed(t)
-
-		NewNumber(reporter, 111).NotInList(float32(111), int64(222)).
-			chain.assertFailed(t)
-
-		NewNumber(reporter, 111).InList(222, 333).
-			chain.assertFailed(t)
-
-		NewNumber(reporter, 111).NotInList(222, 333).
-			chain.assertNotFailed(t)
+				NewNumber(reporter, instance.number).
+					InList(instance.list...).
+					chain.assertFailed(t)
+			}
+		}
 	})
 
 	t.Run("invalid argument", func(t *testing.T) {


### PR DESCRIPTION
This addresses issue #309 by creating table-driven test for "basic" subtest and creating new numbers for each individual test of "canonized" and "invalid argument" that wasn't converted to be table-driven for the following tests:
- TestNumber_IsEqual
- TestNumber_InRange
- TestNumber_InList
- TestNumber_IsGreater
- TestNumber_IsLesser

In addition, some clean up was performed by replacing instances of `cases := map[string]struct {...}` with slices of structs. This was performed for both `TestNumber_IsEqual` and `TestNumber_InDelta`. The paradigm was applied to the tests converted to table-driven style too.