### PR TITLE
refactor request url interpolate tests

### DIFF
--- a/request.go
+++ b/request.go
@@ -145,39 +145,42 @@ func newRequest(
 }
 
 func (r *Request) initPath(opChain *chain, path string, pathargs ...interface{}) {
-	var n int
+	if len(pathargs) != 0 {
+		var n int
 
-	path, err := interpol.WithFunc(path, func(k string, w io.Writer) error {
-		if n < len(pathargs) {
-			if pathargs[n] == nil {
-				opChain.fail(AssertionFailure{
-					Type:   AssertValid,
-					Actual: &AssertionValue{pathargs},
-					Errors: []error{
-						fmt.Errorf("unexpected nil argument at index %d", n),
-					},
-				})
+		var err error
+		path, err = interpol.WithFunc(path, func(k string, w io.Writer) error {
+			if n < len(pathargs) {
+				if pathargs[n] == nil {
+					opChain.fail(AssertionFailure{
+						Type:   AssertValid,
+						Actual: &AssertionValue{pathargs},
+						Errors: []error{
+							fmt.Errorf("unexpected nil argument at index %d", n),
+						},
+					})
+				} else {
+					mustWrite(w, fmt.Sprint(pathargs[n]))
+				}
 			} else {
-				mustWrite(w, fmt.Sprint(pathargs[n]))
+				mustWrite(w, "{")
+				mustWrite(w, k)
+				mustWrite(w, "}")
 			}
-		} else {
-			mustWrite(w, "{")
-			mustWrite(w, k)
-			mustWrite(w, "}")
-		}
-		n++
-		return nil
-	})
-
-	if err != nil {
-		opChain.fail(AssertionFailure{
-			Type:   AssertValid,
-			Actual: &AssertionValue{path},
-			Errors: []error{
-				errors.New("invalid interpol string"),
-				err,
-			},
+			n++
+			return nil
 		})
+
+		if err != nil {
+			opChain.fail(AssertionFailure{
+				Type:   AssertValid,
+				Actual: &AssertionValue{path},
+				Errors: []error{
+					errors.New("invalid interpol string"),
+					err,
+				},
+			})
+		}
 	}
 
 	r.path = path

--- a/request.go
+++ b/request.go
@@ -874,16 +874,6 @@ func (r *Request) WithPath(key string, value interface{}) *Request {
 		return r
 	}
 
-	if value == nil {
-		opChain.fail(AssertionFailure{
-			Type: AssertUsage,
-			Errors: []error{
-				errors.New("unexpected nil argument"),
-			},
-		})
-		return r
-	}
-
 	r.withPath(opChain, key, value)
 
 	return r


### PR DESCRIPTION
#326 
@gavv Hi! Check out please. I split tests into subtests, but I couldn't think of a case when `invalid interpol string` error is returned. And there was an issue with checking value on nil, it was duplicated in [here](https://github.com/gavv/httpexpect/blob/master/request.go#L964) and [here](https://github.com/gavv/httpexpect/blob/master/request.go#L877)