### PR TITLE
response reader

### DIFF
--- a/e2e/chunked_test.go
+++ b/e2e/chunked_test.go
@@ -119,11 +119,13 @@ func TestE2EChunked_ResponseReader(t *testing.T) {
 	})
 	reader := e.GET("/test").Expect().Reader()
 	defer reader.Close()
-	assert.NotNil(t, reader)
 
 	rb := make([]byte, 1000000)
 	l, err := reader.Read(rb)
 	assert.NoError(t, err)
 	assert.Equal(t, 1000000, l)
 	assert.Equal(t, chars, string(rb[0:26]))
+
+	err = reader.Close()
+	assert.NoError(t, err)
 }

--- a/e2e/chunked_test.go
+++ b/e2e/chunked_test.go
@@ -112,7 +112,7 @@ func TestE2EChunked_ResponseReader(t *testing.T) {
 			}
 		}
 		w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-		w.Write(b)
+		_, _ = w.Write(b)
 	})
 	e := httpexpect.WithConfig(httpexpect.Config{
 		BaseURL:  "http://example.com",

--- a/e2e/chunked_test.go
+++ b/e2e/chunked_test.go
@@ -98,3 +98,36 @@ func TestE2EChunked_BinderFast(t *testing.T) {
 		},
 	}))
 }
+
+func TestE2EChunked_ResponseReader(t *testing.T) {
+	const chars = "abcdefghijklmnopqrstuvwxyz"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, 1000000)
+		for i := range b {
+			if i < 26 {
+				b[i] = chars[i]
+			} else {
+				b[i] = chars[i%26]
+			}
+		}
+		w.Header().Add("Content-Type", "text/plain; charset=utf-8")
+		w.Write(b)
+	})
+	e := httpexpect.WithConfig(httpexpect.Config{
+		BaseURL:  "http://example.com",
+		Reporter: httpexpect.NewAssertReporter(t),
+		Client: &http.Client{
+			Transport: httpexpect.NewBinder(mux),
+		},
+	})
+	reader := e.GET("/test").Expect().Reader()
+	defer reader.Close()
+	assert.NotNil(t, reader)
+
+	rb := make([]byte, 26)
+	l, err := reader.Read(rb)
+	assert.NoError(t, err)
+	assert.Equal(t, 26, l)
+	assert.Equal(t, chars, string(rb))
+}

--- a/e2e/chunked_test.go
+++ b/e2e/chunked_test.go
@@ -105,11 +105,7 @@ func TestE2EChunked_ResponseReader(t *testing.T) {
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		b := make([]byte, 1000000)
 		for i := range b {
-			if i < 26 {
-				b[i] = chars[i]
-			} else {
-				b[i] = chars[i%26]
-			}
+			b[i] = chars[i%26]
 		}
 		w.Header().Add("Content-Type", "text/plain; charset=utf-8")
 		_, _ = w.Write(b)
@@ -125,9 +121,9 @@ func TestE2EChunked_ResponseReader(t *testing.T) {
 	defer reader.Close()
 	assert.NotNil(t, reader)
 
-	rb := make([]byte, 26)
+	rb := make([]byte, 1000000)
 	l, err := reader.Read(rb)
 	assert.NoError(t, err)
-	assert.Equal(t, 26, l)
-	assert.Equal(t, chars, string(rb))
+	assert.Equal(t, 1000000, l)
+	assert.Equal(t, chars, string(rb[0:26]))
 }

--- a/e2e/chunked_test.go
+++ b/e2e/chunked_test.go
@@ -118,7 +118,6 @@ func TestE2EChunked_ResponseReader(t *testing.T) {
 		},
 	})
 	reader := e.GET("/test").Expect().Reader()
-	defer reader.Close()
 
 	rb := make([]byte, 1000000)
 	l, err := reader.Read(rb)

--- a/response.go
+++ b/response.go
@@ -1012,20 +1012,11 @@ func (r *Response) Reader() io.ReadCloser {
 
 	resp := r.httpResp
 	bw, ok := resp.Body.(*bodyWrapper)
-	if !ok {
+	if !ok || bw == nil {
 		opChain.fail(AssertionFailure{
 			Type: AssertType,
 			Errors: []error{
 				errors.New("body is not type bodyWrapper"),
-			},
-		})
-		return nil
-	}
-	if bw == nil {
-		opChain.fail(AssertionFailure{
-			Type: AssertNotNil,
-			Errors: []error{
-				errors.New("bodyWrapper is nil"),
 			},
 		})
 		return nil

--- a/response.go
+++ b/response.go
@@ -1012,9 +1012,12 @@ func (r *Response) Reader() io.ReadCloser {
 
 	resp := r.httpResp
 	bw, ok := resp.Body.(*bodyWrapper)
-	if !ok || bw == nil {
+	if !ok {
 		opChain.fail(AssertionFailure{
 			Type: AssertType,
+			Actual: &AssertionValue{
+				Value: bodyWrapper{},
+			},
 			Errors: []error{
 				errors.New("body is not type bodyWrapper"),
 			},

--- a/response.go
+++ b/response.go
@@ -974,6 +974,15 @@ func (r *Response) getJSONP(
 	return value
 }
 
+// Reader returns the body reader from the response.
+//
+// Reader replaces the other methods for reading response body
+// and disables rewinding when reading.
+//
+// Example:
+//
+//	resp := NewResponse(t, response)
+//	reader := resp.Reader()
 func (r *Response) Reader() io.ReadCloser {
 	opChain := r.chain.enter("Reader()")
 	defer opChain.leave()

--- a/response_test.go
+++ b/response_test.go
@@ -1705,6 +1705,19 @@ func TestResponse_Reader(t *testing.T) {
 		assert.NotNil(t, reader)
 		assert.Equal(t, contentHijacked, resp.contentState)
 		assert.Equal(t, "", resp.contentMethod)
+		resp.chain.assert(t, success)
+	})
+	t.Run("incorrect body type", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       newMockBody("test body"),
+		}
+		resp := NewResponse(reporter, httpResp)
+		resp.httpResp.Body = nil
+
+		reader := resp.Reader()
+		assert.Nil(t, reader)
 	})
 	t.Run("Body()", func(t *testing.T) {
 		reporter := newMockReporter(t)
@@ -1723,7 +1736,7 @@ func TestResponse_Reader(t *testing.T) {
 
 		reader := resp.Reader()
 		assert.Nil(t, reader)
-		resp.chain.assertFlags(t, flagFailed)
+		resp.chain.assert(t, failure)
 	})
 	t.Run("Text()", func(t *testing.T) {
 		reporter := newMockReporter(t)
@@ -1742,7 +1755,7 @@ func TestResponse_Reader(t *testing.T) {
 
 		reader := resp.Reader()
 		assert.Nil(t, reader)
-		resp.chain.assertFlags(t, flagFailed)
+		resp.chain.assert(t, failure)
 	})
 	t.Run("Form()", func(t *testing.T) {
 		reporter := newMockReporter(t)
@@ -1763,7 +1776,7 @@ func TestResponse_Reader(t *testing.T) {
 
 		reader := resp.Reader()
 		assert.Nil(t, reader)
-		resp.chain.assertFlags(t, flagFailed)
+		resp.chain.assert(t, failure)
 	})
 	t.Run("JSON()", func(t *testing.T) {
 		reporter := newMockReporter(t)
@@ -1784,7 +1797,7 @@ func TestResponse_Reader(t *testing.T) {
 
 		reader := resp.Reader()
 		assert.Nil(t, reader)
-		resp.chain.assertFlags(t, flagFailed)
+		resp.chain.assert(t, failure)
 	})
 	t.Run("JSONP()", func(t *testing.T) {
 		reporter := newMockReporter(t)
@@ -1802,6 +1815,6 @@ func TestResponse_Reader(t *testing.T) {
 
 		reader := resp.Reader()
 		assert.Nil(t, reader)
-		resp.chain.assertFlags(t, flagFailed)
+		resp.chain.assert(t, failure)
 	})
 }

--- a/response_test.go
+++ b/response_test.go
@@ -591,7 +591,7 @@ func TestResponse_BodyDeferred(t *testing.T) {
 
 		// Invoke getContent()
 		chain := resp.chain.enter("Test()")
-		content, ok := resp.getContent(chain)
+		content, ok := resp.getContent(chain, "Test()")
 
 		chain.assert(t, failure)
 		assert.Nil(t, content)

--- a/response_test.go
+++ b/response_test.go
@@ -1718,6 +1718,7 @@ func TestResponse_Reader(t *testing.T) {
 
 		reader := resp.Reader()
 		assert.Nil(t, reader)
+		resp.chain.assert(t, failure)
 	})
 	t.Run("Body()", func(t *testing.T) {
 		reporter := newMockReporter(t)

--- a/response_test.go
+++ b/response_test.go
@@ -602,6 +602,20 @@ func TestResponse_BodyDeferred(t *testing.T) {
 		assert.Nil(t, resp.content)
 		assert.Equal(t, contentFailed, resp.contentState)
 	})
+
+	t.Run("content hijacked", func(t *testing.T) {
+		reporter := newMockReporter(t)
+
+		body := newMockBody("test")
+		resp := NewResponse(reporter, &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+		})
+		resp.contentState = contentHijacked
+
+		text := resp.Text()
+		text.IsEmpty()
+	})
 }
 
 func TestResponse_NoContent(t *testing.T) {
@@ -1672,5 +1686,122 @@ func TestResponse_Usage(t *testing.T) {
 		}
 		resp.JSONP("foo", contentOpts1, contentOpts2)
 		resp.chain.assert(t, failure)
+	})
+}
+
+func TestResponse_Reader(t *testing.T) {
+	t.Run("get reader", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header(map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+			}),
+			Body: newMockBody("test body"),
+		}
+		resp := NewResponse(reporter, httpResp)
+
+		reader := resp.Reader()
+		assert.NotNil(t, reader)
+		assert.Equal(t, contentHijacked, resp.contentState)
+		assert.Equal(t, "", resp.contentMethod)
+	})
+	t.Run("Body()", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header(map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+			}),
+			Body: newMockBody("test body"),
+		}
+		resp := NewResponse(reporter, httpResp)
+
+		body := resp.Body()
+		assert.Equal(t, "test body", body.value)
+		assert.Equal(t, resp.contentMethod, "Body()")
+
+		reader := resp.Reader()
+		assert.Nil(t, reader)
+		resp.chain.assertFlags(t, flagFailed)
+	})
+	t.Run("Text()", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header(map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+			}),
+			Body: newMockBody("test text"),
+		}
+		resp := NewResponse(reporter, httpResp)
+
+		txt := resp.Text()
+		assert.Equal(t, "test text", txt.value)
+		assert.Equal(t, resp.contentMethod, "Text()")
+
+		reader := resp.Reader()
+		assert.Nil(t, reader)
+		resp.chain.assertFlags(t, flagFailed)
+	})
+	t.Run("Form()", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header(map[string][]string{
+				"Content-Type": {"application/x-www-form-urlencoded"},
+			}),
+			Body: newMockBody("x=1&y=0"),
+		}
+		resp := NewResponse(reporter, httpResp)
+
+		form := resp.Form()
+		form.IsEqual(map[string]string{
+			"x": "1",
+			"y": "0",
+		})
+
+		reader := resp.Reader()
+		assert.Nil(t, reader)
+		resp.chain.assertFlags(t, flagFailed)
+	})
+	t.Run("JSON()", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header(map[string][]string{
+				"Content-Type": {"application/json"},
+			}),
+			Body: newMockBody(`{"a":"test","b":"value"}`),
+		}
+		resp := NewResponse(reporter, httpResp)
+
+		json := resp.JSON()
+		json.IsEqual(map[string]string{
+			"a": "test",
+			"b": "value",
+		})
+
+		reader := resp.Reader()
+		assert.Nil(t, reader)
+		resp.chain.assertFlags(t, flagFailed)
+	})
+	t.Run("JSONP()", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		httpResp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header(map[string][]string{
+				"Content-Type": {"application/javascript; charset=utf-8"},
+			}),
+			Body: newMockBody(`cb({"test_key":"test_value"})`),
+		}
+		resp := NewResponse(reporter, httpResp)
+
+		value := resp.JSONP("cb")
+		value.IsEqual(map[string]string{"test_key": "test_value"})
+
+		reader := resp.Reader()
+		assert.Nil(t, reader)
+		resp.chain.assertFlags(t, flagFailed)
 	})
 }

--- a/response_test.go
+++ b/response_test.go
@@ -606,15 +606,17 @@ func TestResponse_BodyDeferred(t *testing.T) {
 	t.Run("content hijacked", func(t *testing.T) {
 		reporter := newMockReporter(t)
 
-		body := newMockBody("test")
 		resp := NewResponse(reporter, &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       body,
+			Header: map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+			},
+			Body: newMockBody("hijacked body"),
 		})
 		resp.contentState = contentHijacked
 
-		text := resp.Text()
-		text.IsEmpty()
+		body := resp.Body()
+		body.IsEmpty()
 	})
 }
 


### PR DESCRIPTION
#382 

reader func
- [x] validate before read
  - [x] check if the chain is failed
  - [x] check contentState
  - [x] check if the underlying type of resp.Body is bodyWrapper
- [x] call bodyWrapper.DisableRewinds
- [x] set contentState to contentHijacked
- [x] return resp.Body
- [x] report failure if getContent() was already called

other changes
- [x] getContent should be modified to report failure if contentState is contentHijacked
- [x] pass called method to get body
  - [x] Body
  - [x] Text
  - [x] Form
  - [x] JSON
  - [x] JSONP

tests
  - [x] update TestResponse_BodyDeferred
  - [x] Response.Reader
  - [x] getContent() and Reader() cannot be called together
  - [x] e2e/chunked_test.go

