### PR TITLE
Add reentrancy tests for chain assertion handler (#255)

### DIFF
--- a/chain_test.go
+++ b/chain_test.go
@@ -17,6 +17,47 @@ func testFailure() AssertionFailure {
 	}
 }
 
+func TestChain_Reentrancy(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		assertionHandler := &mockAssertionHandler{}
+
+		chain := newChainWithConfig("root", Config{
+			AssertionHandler: assertionHandler,
+		}.withDefaults())
+
+		chain2 := chain.enter("test")
+		assertionHandler.assertionCb = func() {
+			chain2.env() // will hang if lock chain's lock is used to call Failure()
+		}
+
+		chain2.leave()
+
+		assert.False(t, chain2.failed())
+		assert.Equal(t, 1, assertionHandler.successCalled)
+		assert.Equal(t, 0, assertionHandler.failureCalled)
+	})
+
+	t.Run("Failure", func(t *testing.T) {
+		assertionHandler := &mockAssertionHandler{}
+
+		chain := newChainWithConfig("root", Config{
+			AssertionHandler: assertionHandler,
+		}.withDefaults())
+
+		chain2 := chain.enter("test")
+		assertionHandler.assertionCb = func() {
+			chain2.env() // will hang if lock chain's lock is used to call Failure()
+		}
+
+		chain2.fail(testFailure())
+		chain2.leave()
+
+		assert.True(t, chain2.failed())
+		assert.Equal(t, 1, assertionHandler.failureCalled)
+		assert.Equal(t, 0, assertionHandler.successCalled)
+	})
+}
+
 func TestChain_Basic(t *testing.T) {
 	t.Run("clone", func(t *testing.T) {
 		chain1 := newMockChain(t)
@@ -813,56 +854,4 @@ func TestChain_TestingTB(t *testing.T) {
 			assert.Equal(t, tc.want, chain.context.TestingTB)
 		})
 	}
-}
-
-type reenteringAssertionHandler struct {
-	chain *chain
-
-	successCalled bool
-	failureCalled bool
-}
-
-func (mh *reenteringAssertionHandler) Success(ctx *AssertionContext) {
-	mh.successCalled = true
-	mh.chain.env() // will hang if lock chain's lock is used to call Success()
-}
-
-func (mh *reenteringAssertionHandler) Failure(
-	_ *AssertionContext, _ *AssertionFailure,
-) {
-	mh.failureCalled = true
-	mh.chain.env() // will hang if lock chain's lock is used to call Failure()
-}
-
-func TestChain_Reentrancy_Success(t *testing.T) {
-	assertionHandler := &reenteringAssertionHandler{}
-
-	chain := newChainWithConfig("root", Config{
-		AssertionHandler: assertionHandler,
-	}.withDefaults())
-
-	chain2 := chain.enter("test")
-	assertionHandler.chain = chain2
-
-	chain2.leave()
-
-	assert.False(t, chain2.failed())
-	assert.True(t, assertionHandler.successCalled)
-}
-
-func TestChain_Reentrancy_Failure(t *testing.T) {
-	assertionHandler := &reenteringAssertionHandler{}
-
-	chain := newChainWithConfig("root", Config{
-		AssertionHandler: assertionHandler,
-	}.withDefaults())
-
-	chain2 := chain.enter("test")
-	assertionHandler.chain = chain2
-
-	chain2.fail(testFailure())
-	chain2.leave()
-
-	assert.True(t, chain2.failed())
-	assert.True(t, assertionHandler.failureCalled)
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -84,12 +84,20 @@ func (mf *mockFormatter) FormatFailure(
 
 // mock assertion handler
 type mockAssertionHandler struct {
-	ctx     *AssertionContext
-	failure *AssertionFailure
+	ctx           *AssertionContext
+	failure       *AssertionFailure
+	successCalled int
+	failureCalled int
+	assertionCb   func()
 }
 
 func (mh *mockAssertionHandler) Success(ctx *AssertionContext) {
 	mh.ctx = ctx
+	mh.successCalled++
+
+	if mh.assertionCb != nil {
+		mh.assertionCb()
+	}
 }
 
 func (mh *mockAssertionHandler) Failure(
@@ -97,6 +105,11 @@ func (mh *mockAssertionHandler) Failure(
 ) {
 	mh.ctx = ctx
 	mh.failure = failure
+	mh.failureCalled++
+
+	if mh.assertionCb != nil {
+		mh.assertionCb()
+	}
 }
 
 // mock websocket printer


### PR DESCRIPTION
Tests for #255, I verified that adding Lock() calls in chain.go prior to calling handler.Success() or handler.Failure() caused the respective test to hang.

Please review @gavv 