### PR TITLE
chore(value_test): Splitting testvalue_schema test to subtests

### DIFF
--- a/value_test.go
+++ b/value_test.go
@@ -1130,10 +1130,7 @@ func TestValue_PathExpressions(t *testing.T) {
 }
 
 func TestValue_Schema(t *testing.T) {
-	t.Run("schema with valid data", func(t *testing.T) {
-		reporter := newMockReporter(t)
-
-		schema := `{
+	schema := `{
 		"type": "object",
 		"properties": {
 			"foo": {
@@ -1145,93 +1142,49 @@ func TestValue_Schema(t *testing.T) {
 		},
 		"require": ["foo", "bar"]
 		}`
+
+	t.Run("schema with valid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": 1,
 		}
-		NewValue(reporter, data).Schema(schema).chain.assert(t, success)
+		NewValue(reporter, data).Schema(schema).
+			chain.assert(t, success)
 	})
 
 	t.Run("byte slice schema with valid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-
-		schema := `{
-		"type": "object",
-		"properties": {
-			"foo": {
-				"type": "string"
-			},
-			"bar": {
-				"type": "integer"
-			}
-		},
-		"require": ["foo", "bar"]
-		}`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": 1,
 		}
-		NewValue(reporter, data).Schema([]byte(schema)).chain.assert(t, success)
+		NewValue(reporter, data).Schema([]byte(schema)).
+			chain.assert(t, success)
 	})
 
 	t.Run("schema with invalid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-
-		schema := `{
-		"type": "object",
-		"properties": {
-			"foo": {
-				"type": "string"
-			},
-			"bar": {
-				"type": "integer"
-			}
-		},
-		"require": ["foo", "bar"]
-		}`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": "b",
 		}
-		NewValue(reporter, data).Schema(schema).chain.assert(t, failure)
+		NewValue(reporter, data).Schema(schema).
+			chain.assert(t, failure)
 	})
 
 	t.Run("byte slice schema with invalid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-
-		schema := `{
-		"type": "object",
-		"properties": {
-			"foo": {
-				"type": "string"
-			},
-			"bar": {
-				"type": "integer"
-			}
-		},
-		"require": ["foo", "bar"]
-		}`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": "b",
 		}
-		NewValue(reporter, data).Schema([]byte(schema)).chain.assert(t, failure)
+		NewValue(reporter, data).Schema([]byte(schema)).
+			chain.assert(t, failure)
 	})
 
 	t.Run("schema from unmarshalled JSON with valid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-		schema := `{
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "type": "string"
-                },
-                "bar": {
-                    "type": "integer"
-                }
-            },
-            "required": ["foo", "bar"]
-        }`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": 1,
@@ -1239,23 +1192,12 @@ func TestValue_Schema(t *testing.T) {
 		var b interface{}
 		err := json.Unmarshal([]byte(schema), &b)
 		require.Nil(t, err)
-		NewValue(reporter, data).Schema(b).chain.assert(t, success)
+		NewValue(reporter, data).Schema(b).
+			chain.assert(t, success)
 	})
 
 	t.Run("schema from unmarshalled JSON with invalid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-		schema := `{
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "type": "string"
-                },
-                "bar": {
-                    "type": "integer"
-                }
-            },
-            "required": ["foo", "bar"]
-        }`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": "b",
@@ -1263,23 +1205,12 @@ func TestValue_Schema(t *testing.T) {
 		var b interface{}
 		err := json.Unmarshal([]byte(schema), &b)
 		require.Nil(t, err)
-		NewValue(reporter, data).Schema(b).chain.assert(t, failure)
+		NewValue(reporter, data).Schema(b).
+			chain.assert(t, failure)
 	})
 
 	t.Run("schema with valid file url with valid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-		schema := `{
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "type": "string"
-                },
-                "bar": {
-                    "type": "integer"
-                }
-            },
-            "required": ["foo", "bar"]
-        }`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": 1,
@@ -1294,23 +1225,12 @@ func TestValue_Schema(t *testing.T) {
 		require.Nil(t, err)
 
 		url := "file://" + tmp.Name()
-		NewValue(reporter, data).Schema(url).chain.assert(t, success)
+		NewValue(reporter, data).Schema(url).
+			chain.assert(t, success)
 	})
 
 	t.Run("schema with valid file url with invalid data", func(t *testing.T) {
 		reporter := newMockReporter(t)
-		schema := `{
-            "type": "object",
-            "properties": {
-                "foo": {
-                    "type": "string"
-                },
-                "bar": {
-                    "type": "integer"
-                }
-            },
-            "required": ["foo", "bar"]
-        }`
 		data := map[string]interface{}{
 			"foo": "a",
 			"bar": "b",
@@ -1326,7 +1246,8 @@ func TestValue_Schema(t *testing.T) {
 		require.Nil(t, err)
 
 		url := "file://" + tmp.Name()
-		NewValue(reporter, data).Schema(url).chain.assert(t, failure)
+		NewValue(reporter, data).Schema(url).
+			chain.assert(t, failure)
 	})
 
 	t.Run("invalid schema file url", func(t *testing.T) {
@@ -1335,7 +1256,8 @@ func TestValue_Schema(t *testing.T) {
 			"foo": "a",
 			"bar": 1,
 		}
-		NewValue(reporter, data).Schema("file:///bad/path").chain.assert(t, failure)
+		NewValue(reporter, data).Schema("file:///bad/path").
+			chain.assert(t, failure)
 	})
 
 	t.Run("invalid schema json", func(t *testing.T) {
@@ -1344,6 +1266,7 @@ func TestValue_Schema(t *testing.T) {
 			"foo": "a",
 			"bar": 1,
 		}
-		NewValue(reporter, data).Schema("{ bad json").chain.assert(t, failure)
+		NewValue(reporter, data).Schema("{ bad json").
+			chain.assert(t, failure)
 	})
 }

--- a/value_test.go
+++ b/value_test.go
@@ -1130,9 +1130,10 @@ func TestValue_PathExpressions(t *testing.T) {
 }
 
 func TestValue_Schema(t *testing.T) {
-	reporter := newMockReporter(t)
+	t.Run("schema with valid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
-	schema := `{
+		schema := `{
 		"type": "object",
 		"properties": {
 			"foo": {
@@ -1143,45 +1144,206 @@ func TestValue_Schema(t *testing.T) {
 			}
 		},
 		"require": ["foo", "bar"]
-	}`
+		}`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": 1,
+		}
+		NewValue(reporter, data).Schema(schema).chain.assert(t, success)
+	})
 
-	data1 := map[string]interface{}{
-		"foo": "a",
-		"bar": 1,
-	}
+	t.Run("byte slice schema with valid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
-	data2 := map[string]interface{}{
-		"foo": "a",
-		"bar": "b",
-	}
+		schema := `{
+		"type": "object",
+		"properties": {
+			"foo": {
+				"type": "string"
+			},
+			"bar": {
+				"type": "integer"
+			}
+		},
+		"require": ["foo", "bar"]
+		}`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": 1,
+		}
+		NewValue(reporter, data).Schema([]byte(schema)).chain.assert(t, success)
+	})
 
-	NewValue(reporter, data1).Schema(schema).chain.assert(t, success)
-	NewValue(reporter, data2).Schema(schema).chain.assert(t, failure)
+	t.Run("schema with invalid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
-	NewValue(reporter, data1).Schema([]byte(schema)).chain.assert(t, success)
-	NewValue(reporter, data2).Schema([]byte(schema)).chain.assert(t, failure)
+		schema := `{
+		"type": "object",
+		"properties": {
+			"foo": {
+				"type": "string"
+			},
+			"bar": {
+				"type": "integer"
+			}
+		},
+		"require": ["foo", "bar"]
+		}`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": "b",
+		}
+		NewValue(reporter, data).Schema(schema).chain.assert(t, failure)
+	})
 
-	var b interface{}
-	err := json.Unmarshal([]byte(schema), &b)
-	require.Nil(t, err)
+	t.Run("byte slice schema with invalid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
 
-	NewValue(reporter, data1).Schema(b).chain.assert(t, success)
-	NewValue(reporter, data2).Schema(b).chain.assert(t, failure)
+		schema := `{
+		"type": "object",
+		"properties": {
+			"foo": {
+				"type": "string"
+			},
+			"bar": {
+				"type": "integer"
+			}
+		},
+		"require": ["foo", "bar"]
+		}`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": "b",
+		}
+		NewValue(reporter, data).Schema([]byte(schema)).chain.assert(t, failure)
+	})
 
-	tmp, _ := ioutil.TempFile("", "httpexpect")
-	defer os.Remove(tmp.Name())
+	t.Run("schema from unmarshalled JSON with valid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		schema := `{
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                },
+                "bar": {
+                    "type": "integer"
+                }
+            },
+            "required": ["foo", "bar"]
+        }`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": 1,
+		}
+		var b interface{}
+		err := json.Unmarshal([]byte(schema), &b)
+		require.Nil(t, err)
+		NewValue(reporter, data).Schema(b).chain.assert(t, success)
+	})
 
-	_, err = tmp.Write([]byte(schema))
-	require.Nil(t, err)
+	t.Run("schema from unmarshalled JSON with invalid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		schema := `{
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                },
+                "bar": {
+                    "type": "integer"
+                }
+            },
+            "required": ["foo", "bar"]
+        }`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": "b",
+		}
+		var b interface{}
+		err := json.Unmarshal([]byte(schema), &b)
+		require.Nil(t, err)
+		NewValue(reporter, data).Schema(b).chain.assert(t, failure)
+	})
 
-	err = tmp.Close()
-	require.Nil(t, err)
+	t.Run("schema with valid file url with valid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		schema := `{
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                },
+                "bar": {
+                    "type": "integer"
+                }
+            },
+            "required": ["foo", "bar"]
+        }`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": 1,
+		}
+		tmp, _ := ioutil.TempFile("", "httpexpect")
+		defer os.Remove(tmp.Name())
 
-	url := "file://" + tmp.Name()
+		_, err := tmp.Write([]byte(schema))
+		require.Nil(t, err)
 
-	NewValue(reporter, data1).Schema(url).chain.assert(t, success)
-	NewValue(reporter, data2).Schema(url).chain.assert(t, failure)
+		err = tmp.Close()
+		require.Nil(t, err)
 
-	NewValue(reporter, data1).Schema("file:///bad/path").chain.assert(t, failure)
-	NewValue(reporter, data1).Schema("{ bad json").chain.assert(t, failure)
+		url := "file://" + tmp.Name()
+		NewValue(reporter, data).Schema(url).chain.assert(t, success)
+	})
+
+	t.Run("schema with valid file url with invalid data", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		schema := `{
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                },
+                "bar": {
+                    "type": "integer"
+                }
+            },
+            "required": ["foo", "bar"]
+        }`
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": "b",
+		}
+
+		tmp, _ := ioutil.TempFile("", "httpexpect")
+		defer os.Remove(tmp.Name())
+
+		_, err := tmp.Write([]byte(schema))
+		require.Nil(t, err)
+
+		err = tmp.Close()
+		require.Nil(t, err)
+
+		url := "file://" + tmp.Name()
+		NewValue(reporter, data).Schema(url).chain.assert(t, failure)
+	})
+
+	t.Run("invalid schema file url", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": 1,
+		}
+		NewValue(reporter, data).Schema("file:///bad/path").chain.assert(t, failure)
+	})
+
+	t.Run("invalid schema json", func(t *testing.T) {
+		reporter := newMockReporter(t)
+		data := map[string]interface{}{
+			"foo": "a",
+			"bar": 1,
+		}
+		NewValue(reporter, data).Schema("{ bad json").chain.assert(t, failure)
+	})
 }


### PR DESCRIPTION
This PR splits the `TestValue_schema` test into multiple subtests to improve readability and maintenance.  

This is per issue #385.