### PR TITLE
Update to free memory after disabling rewinds for bodyWrapper

### DIFF
--- a/body_wrapper_test.go
+++ b/body_wrapper_test.go
@@ -742,7 +742,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		wrp.DisableRewinds()
 
 		assert.False(t, wrp.isFullyRead)
-		assert.Equal(t, "1234", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 1, body.readCount)
 		assert.Equal(t, 0, body.closeCount)
@@ -757,7 +757,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		wrp.Rewind()
 
 		assert.False(t, wrp.isFullyRead)
-		assert.Equal(t, "1234", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 1, body.readCount)
 		assert.Equal(t, 0, body.closeCount)
@@ -770,7 +770,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.Equal(t, "5678", string(b))
 
 		assert.False(t, wrp.isFullyRead)
-		assert.Equal(t, "1234", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 2, body.readCount)
 		assert.Equal(t, 0, body.closeCount)
@@ -782,7 +782,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.Equal(t, 0, n)
 
 		assert.False(t, wrp.isFullyRead)
-		assert.Equal(t, "1234", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 3, body.readCount)
 		assert.Equal(t, 0, body.closeCount)
@@ -793,7 +793,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.False(t, wrp.isFullyRead)
-		assert.Equal(t, "1234", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 3, body.readCount)
 		assert.Equal(t, 1, body.closeCount)
@@ -860,7 +860,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.Equal(t, 0, n)
 
 		assert.True(t, wrp.isFullyRead)
-		assert.Equal(t, "12345678", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 2, body.readCount)
 		assert.Equal(t, 1, body.closeCount)
@@ -871,7 +871,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, wrp.isFullyRead)
-		assert.Equal(t, "12345678", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 2, body.readCount)
 		assert.Equal(t, 1, body.closeCount)
@@ -967,7 +967,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.Equal(t, 0, n)
 
 		assert.True(t, wrp.isFullyRead)
-		assert.Equal(t, "12345678", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 2, body.readCount)
 		assert.Equal(t, 1, body.closeCount)
@@ -982,7 +982,7 @@ func TestBodyWrapper_DisableRewinds(t *testing.T) {
 		assert.Equal(t, 0, n)
 
 		assert.True(t, wrp.isFullyRead)
-		assert.Equal(t, "12345678", string(wrp.memBytes))
+		assert.Nil(t, wrp.memBytes)
 
 		assert.Equal(t, 2, body.readCount)
 		assert.Equal(t, 1, body.closeCount)


### PR DESCRIPTION
This addresses issue #381.

So far in this PR, cached HTTP response body is freed from memory in two cases:
1. `DisableRewinds` is called and the full HTTP response body has not been cached in memory.
2. A read from memory via `memReadNext` occurs and hits a EOF.

---
There are two additional cases where memory is not freed until a read from memory after `DisableRewinds` occurs (e.g. the test case at body_wrapper_test. go line 843):
1. Disabling rewinds immediately after a read via `httpReadNext`.
  - When switching to memReadNext, memReader is set to a new reader on nil. After disabling rewinds, only an additional attempt to Read will trigger a read from memory, which will result in an EOF.
2. Disabling rewinds for cases where a subsequent read will result in EOF.
  - You could assume that an additional read will occur and treat this as a case that's still in the middle of reading a response from memory.

I'm currently investigating if these could be moved to occur within the `DisableRewinds` method.

One option to address these additional cases could be to update the memReader type from `io.Reader` to `bytes.Reader`. This would allow us to implement additional methods like `Len()` ([see documentation](https://pkg.go.dev/bytes#NewReader)) rather than just the Read interface method. The we could do something like:
```
```