### PR TITLE
Rename match.Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,9 +359,9 @@ m := e.GET("/users/john").
 	Expect().
 	Header("Location").Match("http://(?P<host>.+)/users/(?P<user>.+)")
 
-m.Index(0).IsEqual("http://example.com/users/john")
-m.Index(1).IsEqual("example.com")
-m.Index(2).IsEqual("john")
+m.Value(0).IsEqual("http://example.com/users/john")
+m.Value(1).IsEqual("example.com")
+m.Value(2).IsEqual("john")
 
 m.Name("host").IsEqual("example.com")
 m.Name("user").IsEqual("john")

--- a/match.go
+++ b/match.go
@@ -27,9 +27,9 @@ type Match struct {
 //	m.NotEmpty()
 //	m.Length().IsEqual(3)
 //
-//	m.Index(0).IsEqual("http://example.com/users/john")
-//	m.Index(1).IsEqual("example.com")
-//	m.Index(2).IsEqual("john")
+//	m.Value(0).IsEqual("http://example.com/users/john")
+//	m.Value(1).IsEqual("example.com")
+//	m.Value(2).IsEqual("john")
 //
 //	m.Name("host").IsEqual("example.com")
 //	m.Name("user").IsEqual("john")
@@ -103,10 +103,10 @@ func (m *Match) Length() *Number {
 	return newNumber(opChain, float64(len(m.submatches)))
 }
 
-// Index returns a new String instance with submatch for given index.
+// Value returns a new String instance with submatch for given index.
 //
 // Note that submatch with index 0 contains the whole match. If index is out
-// of bounds, Index reports failure and returns empty (but non-nil) instance.
+// of bounds, Value reports failure and returns empty (but non-nil) instance.
 //
 // Example:
 //
@@ -115,11 +115,11 @@ func (m *Match) Length() *Number {
 //	r := regexp.MustCompile(`http://(.+)/users/(.+)`)
 //	m := NewMatch(t, r.FindStringSubmatch(s), nil)
 //
-//	m.Index(0).IsEqual("http://example.com/users/john")
-//	m.Index(1).IsEqual("example.com")
-//	m.Index(2).IsEqual("john")
-func (m *Match) Index(index int) *String {
-	opChain := m.chain.enter("Index(%d)", index)
+//	m.Value(0).IsEqual("http://example.com/users/john")
+//	m.Value(1).IsEqual("example.com")
+//	m.Value(2).IsEqual("john")
+func (m *Match) Value(index int) *String {
+	opChain := m.chain.enter("Value(%d)", index)
 	defer opChain.leave()
 
 	if opChain.failed() {

--- a/match_test.go
+++ b/match_test.go
@@ -15,7 +15,7 @@ func TestMatch_FailedChain(t *testing.T) {
 	value.Alias("foo")
 
 	value.Length().chain.assert(t, failure)
-	value.Index(0).chain.assert(t, failure)
+	value.Value(0).chain.assert(t, failure)
 	value.Name("").chain.assert(t, failure)
 
 	value.IsEmpty()
@@ -66,9 +66,9 @@ func TestMatch_Alias(t *testing.T) {
 	assert.Equal(t, []string{"Match()"}, value.chain.context.Path)
 	assert.Equal(t, []string{"foo"}, value.chain.context.AliasedPath)
 
-	childValue := value.Index(0)
-	assert.Equal(t, []string{"Match()", "Index(0)"}, childValue.chain.context.Path)
-	assert.Equal(t, []string{"foo", "Index(0)"}, childValue.chain.context.AliasedPath)
+	childValue := value.Value(0)
+	assert.Equal(t, []string{"Match()", "Value(0)"}, childValue.chain.context.Path)
+	assert.Equal(t, []string{"foo", "Value(0)"}, childValue.chain.context.AliasedPath)
 }
 
 func TestMatch_Getters(t *testing.T) {
@@ -83,20 +83,20 @@ func TestMatch_Getters(t *testing.T) {
 
 	assert.Equal(t, 3.0, value.Length().Raw())
 
-	assert.Equal(t, "m0", value.Index(0).Raw())
-	assert.Equal(t, "m1", value.Index(1).Raw())
-	assert.Equal(t, "m2", value.Index(2).Raw())
+	assert.Equal(t, "m0", value.Value(0).Raw())
+	assert.Equal(t, "m1", value.Value(1).Raw())
+	assert.Equal(t, "m2", value.Value(2).Raw())
 	value.chain.assert(t, success)
 
 	assert.Equal(t, "m1", value.Name("n1").Raw())
 	assert.Equal(t, "m2", value.Name("n2").Raw())
 	value.chain.assert(t, success)
 
-	assert.Equal(t, "", value.Index(-1).Raw())
+	assert.Equal(t, "", value.Value(-1).Raw())
 	value.chain.assert(t, failure)
 	value.chain.clear()
 
-	assert.Equal(t, "", value.Index(3).Raw())
+	assert.Equal(t, "", value.Value(3).Raw())
 	value.chain.assert(t, failure)
 	value.chain.clear()
 

--- a/string.go
+++ b/string.go
@@ -865,9 +865,9 @@ func (s *String) NotHasSuffixFold(value string) *String {
 //	m.NotEmpty()
 //	m.Length().IsEqual(3)
 //
-//	m.Index(0).IsEqual("http://example.com/users/john")
-//	m.Index(1).IsEqual("example.com")
-//	m.Index(2).IsEqual("john")
+//	m.Value(0).IsEqual("http://example.com/users/john")
+//	m.Value(1).IsEqual("example.com")
+//	m.Value(2).IsEqual("john")
 //
 //	m.Name("host").IsEqual("example.com")
 //	m.Name("user").IsEqual("john")


### PR DESCRIPTION
Issue: https://github.com/gavv/httpexpect/issues/252

Rename `match.Index` to `match.Value`.