### PR TITLE
Added  TestFormatter_FailureContext

### DIFF
--- a/formatter_test.go
+++ b/formatter_test.go
@@ -406,6 +406,74 @@ func TestFormatter_FailureReference(t *testing.T) {
 		})
 	}
 }
+func TestFormatter_FailureContext(t *testing.T) {
+	cases := []struct {
+		name          string
+		assertionType AssertionType
+		testName      string
+		requestName   string
+		path          []string
+		aliasedPath   []string
+	}{
+		{
+			name:          "Assert Equal",
+			assertionType: AssertEqual,
+			testName:      t.Name(),
+			requestName:   "RequestName",
+			path:          []string{"GET"},
+			aliasedPath:   []string{"ALIASGET"},
+		},
+		{
+			name:          "Assert DisableNames",
+			assertionType: AssertEqual,
+			path:          []string{"GET"},
+			aliasedPath:   []string{"ALIASGET"},
+		},
+		{
+			name:          "Assert DisablePaths",
+			assertionType: AssertEqual,
+			testName:      t.Name(),
+			requestName:   "RequestName",
+		},
+		{
+			name:          "Assert DisableAliases",
+			assertionType: AssertEqual,
+			testName:      t.Name(),
+			requestName:   "RequestName",
+			path:          []string{"GET"},
+			aliasedPath:   []string{"ALIASGET"},
+		},
+	}
+
+	ctx := &AssertionContext{TestName: t.Name(), RequestName: "RequestName", Path: []string{"GET"}, AliasedPath: []string{"ALIASGET"}}
+	var fd *FormatData
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fl := &AssertionFailure{
+				Type: tc.assertionType,
+			}
+			if tc.name == "Assert Equal" {
+				df := &DefaultFormatter{}
+				fd = df.buildFormatData(ctx, fl)
+				assert.Equal(t, tc.aliasedPath, fd.AssertPath)
+			} else if tc.name == "Assert DisableNames" {
+				df := &DefaultFormatter{DisableNames: true}
+				fd = df.buildFormatData(ctx, fl)
+				assert.Equal(t, tc.aliasedPath, fd.AssertPath)
+			} else if tc.name == "Assert DisablePaths" {
+				df := &DefaultFormatter{DisablePaths: true}
+				fd = df.buildFormatData(ctx, fl)
+				assert.Equal(t, tc.path, fd.AssertPath)
+			} else if tc.name == "Assert DisableAliases" {
+				df := &DefaultFormatter{DisableAliases: true}
+				fd = df.buildFormatData(ctx, fl)
+				assert.Equal(t, tc.path, fd.AssertPath)
+			}
+			assert.Equal(t, tc.requestName, fd.RequestName)
+			assert.Equal(t, tc.testName, fd.TestName)
+		})
+	}
+}
 
 func TestFormatter_FailureDelta(t *testing.T) {
 	cases := []struct {

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -445,7 +445,12 @@ func TestFormatter_FailureContext(t *testing.T) {
 		},
 	}
 
-	ctx := &AssertionContext{TestName: t.Name(), RequestName: "RequestName", Path: []string{"GET"}, AliasedPath: []string{"ALIASGET"}}
+	ctx := &AssertionContext{
+		TestName:    t.Name(),
+		RequestName: "RequestName",
+		Path:        []string{"GET"},
+		AliasedPath: []string{"ALIASGET"},
+	}
 	var fd *FormatData
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Hi @gavv ,
Have added the Test function for TestFormatter_FailureContext with DisableNames,DisablePaths,DisableAliases formatting options. Please review and guide as this is the first time am contributing to an open source project.
https://github.com/gavv/httpexpect/issues/262