### PR TITLE
Adding macos and windows to github actions #413

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go: [1.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }} 
     name: Go ${{ matrix.go }} ${{ matrix.os }} 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: [1.20]
+        go: [1.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }} 
     name: Go ${{ matrix.go }} ${{ matrix.os }} 
@@ -40,7 +40,7 @@ jobs:
   examples:
     strategy:
       matrix:
-        go: [1.20]
+        go: [1.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }} 
     name: Examples ${{ matrix.go }} ${{ matrix.os }} 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: [1.17, 1.x]
+        go: [1.20]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }} 
     name: Go ${{ matrix.go }} ${{ matrix.os }} 
@@ -40,7 +40,7 @@ jobs:
   examples:
     strategy:
       matrix:
-        go: [1.17, 1.x]
+        go: [1.20]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }} 
     name: Examples ${{ matrix.go }} ${{ matrix.os }} 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,6 +114,7 @@ jobs:
 
       - name: Run linters
         uses: golangci/golangci-lint-action@v3
+        timeout-minutes: 5
         with:
           version: v1.51.2
           working-directory: ${{ matrix.dir }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,21 +15,21 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         go: [1.17, 1.x]
-
-    name: Go ${{ matrix.go }}
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }} 
+    name: Go ${{ matrix.go }} ${{ matrix.os }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4.0.1
         with:
           go-version: ${{ matrix.go }}
+          cache: true
 
       - name: Build
         run: go get -v ./...
@@ -38,17 +38,21 @@ jobs:
         run: go test ./...
 
   examples:
-    runs-on: ubuntu-latest
-
-    name: Examples
+    strategy:
+      matrix:
+        go: [1.17, 1.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }} 
+    name: Examples ${{ matrix.go }} ${{ matrix.os }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4.0.1
         with:
-          go-version: 1.x
+          go-version: ${{ matrix.go }}
+          cache: true
 
       - name: Build
         run: cd _examples && go get -v .
@@ -104,7 +108,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4.0.1
         with:
           go-version: 1.x
 
@@ -124,9 +128,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4.0.1
         with:
           go-version: 1.x
+          cache: true
 
       - name: Run tests
         run: go test -covermode=count -coverprofile=coverage.out -coverpkg=. ./...

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go: [1.17, 1.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }} 
     name: Go ${{ matrix.go }} ${{ matrix.os }} 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,11 @@
 name: build
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master
       - v*
-
   push:
     branches:
       - master

--- a/binder.go
+++ b/binder.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -78,7 +78,7 @@ func (binder Binder) RoundTrip(origReq *http.Request) (*http.Response, error) {
 	}
 
 	if recorder.Body != nil {
-		resp.Body = ioutil.NopCloser(recorder.Body)
+		resp.Body = io.NopCloser(recorder.Body)
 	}
 
 	return &resp, nil
@@ -148,7 +148,7 @@ func (binder FastBinder) RoundTrip(stdreq *http.Request) (*http.Response, error)
 	}
 
 	if stdreq.Body != nil {
-		b, err := ioutil.ReadAll(stdreq.Body)
+		b, err := io.ReadAll(stdreq.Body)
 		if err == nil {
 			ctx.Request.SetBody(b)
 		}
@@ -219,9 +219,9 @@ func fast2std(stdreq *http.Request, fastresp *fasthttp.Response) *http.Response 
 	}
 
 	if body != nil {
-		stdresp.Body = ioutil.NopCloser(bytes.NewReader(body))
+		stdresp.Body = io.NopCloser(bytes.NewReader(body))
 	} else {
-		stdresp.Body = ioutil.NopCloser(bytes.NewReader(nil))
+		stdresp.Body = io.NopCloser(bytes.NewReader(nil))
 	}
 
 	return stdresp

--- a/binder_test.go
+++ b/binder_test.go
@@ -3,7 +3,7 @@ package httpexpect
 import (
 	"bufio"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -20,7 +20,7 @@ type mockHandler struct {
 }
 
 func (c *mockHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	assert.True(c.t, err == nil)
 
 	if c.http10 {
@@ -81,7 +81,7 @@ func TestBinder_Basic(t *testing.T) {
 		"Content-Type": {"application/json"},
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestFastBinder_Basic(t *testing.T) {
 		"Content-Type": {"application/json"},
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestFastBinder_RemoteAddr(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +312,7 @@ func TestFastBinder_Protocol(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -476,7 +476,7 @@ func TestFastBinder_EmptyResponse(t *testing.T) {
 
 	assert.False(t, resp.Body == nil)
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/body_wrapper.go
+++ b/body_wrapper.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"sync"
 )
@@ -178,7 +177,7 @@ func (bw *bodyWrapper) GetBody() (io.ReadCloser, error) {
 	}
 
 	// Return fresh reader for memory chunk.
-	return ioutil.NopCloser(bytes.NewReader(bw.memBytes)), nil
+	return io.NopCloser(bytes.NewReader(bw.memBytes)), nil
 }
 
 // Disables storing body contents in memory and clears the cache.
@@ -223,7 +222,7 @@ func (bw *bodyWrapper) httpReadNext(p []byte) (int, error) {
 }
 
 func (bw *bodyWrapper) httpReadFull() error {
-	b, err := ioutil.ReadAll(bw.httpReader)
+	b, err := io.ReadAll(bw.httpReader)
 
 	// Switch to reading from memory.
 	bw.isFullyRead = true

--- a/body_wrapper_test.go
+++ b/body_wrapper_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,11 +151,11 @@ func TestBodyWrapper_GetBody(t *testing.T) {
 		rd2, err := wrp.GetBody()
 		assert.NoError(t, err)
 
-		b, err := ioutil.ReadAll(rd1)
+		b, err := io.ReadAll(rd1)
 		assert.NoError(t, err)
 		assert.Equal(t, "test_body", string(b))
 
-		b, err = ioutil.ReadAll(rd2)
+		b, err = io.ReadAll(rd2)
 		assert.NoError(t, err)
 		assert.Equal(t, "test_body", string(b))
 
@@ -601,7 +600,7 @@ func TestBodyWrapper_Memory(t *testing.T) {
 		assert.Equal(t, 1, body.eofCount)
 
 		// check body
-		c, err := ioutil.ReadAll(reader)
+		c, err := io.ReadAll(reader)
 		assert.NoError(t, err)
 		assert.Equal(t, "123456789", string(c))
 

--- a/e2e/fs_test.go
+++ b/e2e/fs_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -12,13 +11,13 @@ import (
 )
 
 func TestE2EFs_FastBinder(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "httpexpect")
+	tempdir, err := os.MkdirTemp("", "httpexpect")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempdir)
 
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		path.Join(tempdir, "hello"), []byte("hello, world!"), 0666); err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/printer_test.go
+++ b/e2e/printer_test.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,14 +19,14 @@ type mockPrinter struct {
 
 func (p *mockPrinter) Request(req *http.Request) {
 	if req.Body != nil {
-		p.reqBody, _ = ioutil.ReadAll(req.Body)
+		p.reqBody, _ = io.ReadAll(req.Body)
 		req.Body.Close()
 	}
 }
 
 func (p *mockPrinter) Response(resp *http.Response, rtt time.Duration) {
 	if resp.Body != nil {
-		p.respBody, _ = ioutil.ReadAll(resp.Body)
+		p.respBody, _ = io.ReadAll(resp.Body)
 		resp.Body.Close()
 	}
 	p.rtt = rtt
@@ -36,7 +36,7 @@ func createPrinterHandler() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		if string(body) != "test_request" {
 			panic("unexpected request body " + string(body))
 		}

--- a/e2e/redirect_test.go
+++ b/e2e/redirect_test.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,7 +18,7 @@ func createRedirectHandler() http.Handler {
 		if r.Method == "GET" {
 			_, _ = w.Write([]byte(`default_response`))
 		} else {
-			b, _ := ioutil.ReadAll(r.Body)
+			b, _ := io.ReadAll(r.Body)
 			_, _ = w.Write(b)
 		}
 	})

--- a/e2e/retry_test.go
+++ b/e2e/retry_test.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -75,7 +75,7 @@ func createRetryHandler(rc *retryController) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 
 		w.WriteHeader(rc.getStatus())
 		_, _ = w.Write(b)

--- a/printer_test.go
+++ b/printer_test.go
@@ -3,7 +3,7 @@ package httpexpect
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestPrinter_Compact(t *testing.T) {
 	printer.Request(req2)
 	printer.Request(nil)
 
-	printer.Response(&http.Response{Body: ioutil.NopCloser(body2)}, 0)
+	printer.Response(&http.Response{Body: io.NopCloser(body2)}, 0)
 	printer.Response(&http.Response{}, 0)
 	printer.Response(nil, 0)
 }
@@ -51,7 +51,7 @@ func TestPrinter_Debug(t *testing.T) {
 	printer.Request(req2)
 	printer.Request(nil)
 
-	printer.Response(&http.Response{Body: ioutil.NopCloser(body2)}, 0)
+	printer.Response(&http.Response{Body: io.NopCloser(body2)}, 0)
 	printer.Response(&http.Response{}, 0)
 	printer.Response(nil, 0)
 }

--- a/request.go
+++ b/request.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -1889,7 +1888,7 @@ func (r *Request) WithFile(key, path string, reader ...io.Reader) *Request {
 //
 //	req := NewRequestC(config, "PUT", "http://example.com/path")
 //	fh, _ := os.Open("./john.png")
-//	b, _ := ioutil.ReadAll(fh)
+//	b, _ := io.ReadAll(fh)
 //	req.WithMultipart().
 //		WithFileBytes("avatar", "john.png", b)
 //	fh.Close()
@@ -2427,7 +2426,8 @@ func (r *Request) setupRedirects(opChain *chain) {
 			if _, ok := r.httpReq.Body.(*bodyWrapper); !ok {
 				r.httpReq.Body = newBodyWrapper(r.httpReq.Body, nil)
 			}
-			r.httpReq.GetBody = r.httpReq.Body.(*bodyWrapper).GetBody
+			wrapper := r.httpReq.Body.(*bodyWrapper)
+			r.httpReq.GetBody = wrapper.GetBody
 		} else {
 			r.httpReq.GetBody = func() (io.ReadCloser, error) {
 				return http.NoBody, nil
@@ -2495,7 +2495,7 @@ func (r *Request) setBody(
 		r.httpReq.Body = http.NoBody
 		r.httpReq.ContentLength = 0
 	} else {
-		r.httpReq.Body = ioutil.NopCloser(reader)
+		r.httpReq.Body = io.NopCloser(reader)
 		r.httpReq.ContentLength = int64(len)
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -1730,19 +1729,19 @@ func TestRequest_BodyMultipart(t *testing.T) {
 		part1, _ := reader.NextPart()
 		assert.Equal(t, "b", part1.FormName())
 		assert.Equal(t, "", part1.FileName())
-		b1, _ := ioutil.ReadAll(part1)
+		b1, _ := io.ReadAll(part1)
 		assert.Equal(t, "1", string(b1))
 
 		part2, _ := reader.NextPart()
 		assert.Equal(t, "c", part2.FormName())
 		assert.Equal(t, "", part2.FileName())
-		b2, _ := ioutil.ReadAll(part2)
+		b2, _ := io.ReadAll(part2)
 		assert.Equal(t, "2", string(b2))
 
 		part3, _ := reader.NextPart()
 		assert.Equal(t, "a", part3.FormName())
 		assert.Equal(t, "", part3.FileName())
-		b3, _ := ioutil.ReadAll(part3)
+		b3, _ := io.ReadAll(part3)
 		assert.Equal(t, "3", string(b3))
 
 		eof, _ := reader.NextPart()
@@ -1752,7 +1751,7 @@ func TestRequest_BodyMultipart(t *testing.T) {
 	t.Run("multipart file", func(t *testing.T) {
 		req := NewRequestC(config, "POST", "url")
 
-		fh, _ := ioutil.TempFile("", "httpexpect")
+		fh, _ := os.CreateTemp("", "httpexpect")
 		filename2 := fh.Name()
 		_, _ = fh.WriteString("2")
 		fh.Close()
@@ -1782,25 +1781,25 @@ func TestRequest_BodyMultipart(t *testing.T) {
 		part1, _ := reader.NextPart()
 		assert.Equal(t, "a", part1.FormName())
 		assert.Equal(t, "", part1.FileName())
-		b1, _ := ioutil.ReadAll(part1)
+		b1, _ := io.ReadAll(part1)
 		assert.Equal(t, "1", string(b1))
 
 		part2, _ := reader.NextPart()
 		assert.Equal(t, "b", part2.FormName())
 		assert.Equal(t, filepath.Base(filename2), filepath.Base(part2.FileName()))
-		b2, _ := ioutil.ReadAll(part2)
+		b2, _ := io.ReadAll(part2)
 		assert.Equal(t, "2", string(b2))
 
 		part3, _ := reader.NextPart()
 		assert.Equal(t, "c", part3.FormName())
 		assert.Equal(t, "filename3", filepath.Base(part3.FileName()))
-		b3, _ := ioutil.ReadAll(part3)
+		b3, _ := io.ReadAll(part3)
 		assert.Equal(t, "3", string(b3))
 
 		part4, _ := reader.NextPart()
 		assert.Equal(t, "d", part4.FormName())
 		assert.Equal(t, "filename4", filepath.Base(part4.FileName()))
-		b4, _ := ioutil.ReadAll(part4)
+		b4, _ := io.ReadAll(part4)
 		assert.Equal(t, "4", string(b4))
 
 		eof, _ := reader.NextPart()
@@ -2169,7 +2168,7 @@ func TestRequest_RedirectsDontFollow(t *testing.T) {
 
 		tp := newMockRedirectTransport()
 		tp.assertFn = func(r *http.Request) {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, "test body", string(b))
 		}
@@ -2293,7 +2292,7 @@ func TestRequest_RedirectsFollowAll(t *testing.T) {
 		tp := newMockRedirectTransport()
 		tp.maxRedirects = 1
 		tp.assertFn = func(r *http.Request) {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, "test body", string(b))
 		}
@@ -2317,7 +2316,7 @@ func TestRequest_RedirectsFollowAll(t *testing.T) {
 		// Should set GetBody
 		gb, err := req.httpReq.GetBody()
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(gb)
+		b, err := io.ReadAll(gb)
 		assert.NoError(t, err)
 		assert.Equal(t, "test body", string(b))
 
@@ -2339,7 +2338,7 @@ func TestRequest_RedirectsFollowAll(t *testing.T) {
 
 		tp := newMockRedirectTransport()
 		tp.assertFn = func(r *http.Request) {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, "test body", string(b))
 		}
@@ -2362,7 +2361,7 @@ func TestRequest_RedirectsFollowAll(t *testing.T) {
 		// Should set GetBody
 		gb, err := req.httpReq.GetBody()
 		assert.NoError(t, err)
-		b, err := ioutil.ReadAll(gb)
+		b, err := io.ReadAll(gb)
 		assert.NoError(t, err)
 		assert.Equal(t, "test body", string(b))
 
@@ -2465,7 +2464,7 @@ func TestRequest_RedirectsFollowWithoutBody(t *testing.T) {
 		tp := newMockRedirectTransport()
 		tp.maxRedirects = 1
 		tp.assertFn = func(r *http.Request) {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, "test body", string(b))
 		}
@@ -2512,7 +2511,7 @@ func TestRequest_RedirectsFollowWithoutBody(t *testing.T) {
 			if r.URL.String() == "/url" {
 				assert.Equal(t, r.Method, http.MethodPut)
 
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			} else if r.URL.String() == "/redirect" {
@@ -2564,7 +2563,7 @@ func TestRequest_RedirectsFollowWithoutBody(t *testing.T) {
 			if r.URL.String() == "/url" {
 				assert.Equal(t, r.Method, http.MethodPut)
 
-				b, err := ioutil.ReadAll(r.Body)
+				b, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			} else if r.URL.String() == "/redirect" {
@@ -2618,7 +2617,7 @@ func TestRequest_RetriesDisabled(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2652,7 +2651,7 @@ func TestRequest_RetriesDisabled(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2687,7 +2686,7 @@ func TestRequest_RetriesDisabled(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2723,7 +2722,7 @@ func TestRequest_RetriesDisabled(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2761,7 +2760,7 @@ func TestRequest_RetriesTimeout(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2795,7 +2794,7 @@ func TestRequest_RetriesTimeout(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2831,7 +2830,7 @@ func TestRequest_RetriesTimeout(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2867,7 +2866,7 @@ func TestRequest_RetriesTimeout(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2905,7 +2904,7 @@ func TestRequest_RetriesTimeoutAndServer(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2939,7 +2938,7 @@ func TestRequest_RetriesTimeoutAndServer(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -2975,7 +2974,7 @@ func TestRequest_RetriesTimeoutAndServer(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3012,7 +3011,7 @@ func TestRequest_RetriesTimeoutAndServer(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3050,7 +3049,7 @@ func TestRequest_RetriesAll(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3084,7 +3083,7 @@ func TestRequest_RetriesAll(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3120,7 +3119,7 @@ func TestRequest_RetriesAll(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3157,7 +3156,7 @@ func TestRequest_RetriesAll(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3195,7 +3194,7 @@ func TestRequest_RetriesLimit(t *testing.T) {
 		cb: func(req *http.Request) {
 			callCount++
 
-			b, err := ioutil.ReadAll(req.Body)
+			b, err := io.ReadAll(req.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, "test body", string(b))
 		},
@@ -3233,7 +3232,7 @@ func TestRequest_RetriesDelay(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3275,7 +3274,7 @@ func TestRequest_RetriesDelay(t *testing.T) {
 			cb: func(req *http.Request) {
 				callCount++
 
-				b, err := ioutil.ReadAll(req.Body)
+				b, err := io.ReadAll(req.Body)
 				assert.NoError(t, err)
 				assert.Equal(t, "test body", string(b))
 			},
@@ -3321,7 +3320,7 @@ func TestRequest_RetriesCancellation(t *testing.T) {
 
 			assert.Error(t, req.Context().Err(), context.Canceled.Error())
 
-			b, err := ioutil.ReadAll(req.Body)
+			b, err := io.ReadAll(req.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, "test body", string(b))
 		},

--- a/response.go
+++ b/response.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"reflect"
@@ -169,7 +169,7 @@ func (r *Response) getContent(opChain *chain) ([]byte, bool) {
 		bw.Rewind()
 	}
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 
 	closeErr := resp.Body.Close()
 	if err == nil {

--- a/response_test.go
+++ b/response_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -370,7 +370,7 @@ func TestResponse_BodyOperations(t *testing.T) {
 
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewBufferString("body")),
+			Body:       io.NopCloser(bytes.NewBufferString("body")),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -615,7 +615,7 @@ func TestResponse_NoContent(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			Body:       io.NopCloser(bytes.NewBufferString("")),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -705,7 +705,7 @@ func TestResponse_NoContent(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -931,7 +931,7 @@ func TestResponse_Text(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -998,7 +998,7 @@ func TestResponse_Form(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1043,7 +1043,7 @@ func TestResponse_Form(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1067,7 +1067,7 @@ func TestResponse_Form(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1119,7 +1119,7 @@ func TestResponse_JSON(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1160,7 +1160,7 @@ func TestResponse_JSON(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1184,7 +1184,7 @@ func TestResponse_JSON(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1209,7 +1209,7 @@ func TestResponse_JSON(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1265,7 +1265,7 @@ func TestResponse_JSONP(t *testing.T) {
 					httpResp := &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     http.Header(headers),
-						Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+						Body:       io.NopCloser(bytes.NewBufferString(body)),
 					}
 
 					resp := NewResponse(reporter, httpResp)
@@ -1323,7 +1323,7 @@ func TestResponse_JSONP(t *testing.T) {
 					httpResp := &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     http.Header(headers),
-						Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+						Body:       io.NopCloser(bytes.NewBufferString(body)),
 					}
 
 					resp := NewResponse(reporter, httpResp)
@@ -1349,7 +1349,7 @@ func TestResponse_JSONP(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1374,7 +1374,7 @@ func TestResponse_JSONP(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1430,7 +1430,7 @@ func TestResponse_ContentOpts(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(tc.respBody)),
+			Body:       io.NopCloser(bytes.NewBufferString(tc.respBody)),
 		}
 
 		reporter := newMockReporter(t)
@@ -1608,7 +1608,7 @@ func TestResponse_Usage(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1634,7 +1634,7 @@ func TestResponse_Usage(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
 		}
 
 		resp := NewResponse(reporter, httpResp)
@@ -1660,7 +1660,7 @@ func TestResponse_Usage(t *testing.T) {
 		httpResp := &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header(headers),
-			Body:       ioutil.NopCloser(bytes.NewBufferString(body1)),
+			Body:       io.NopCloser(bytes.NewBufferString(body1)),
 		}
 
 		resp := NewResponse(reporter, httpResp)

--- a/value_test.go
+++ b/value_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1224,7 +1225,11 @@ func TestValue_Schema(t *testing.T) {
 		err = tmp.Close()
 		require.Nil(t, err)
 
-		url := "file://" + tmp.Name()
+		url := "file://"
+		if runtime.GOOS == "windows" {
+			url = url + "/"
+		}
+		url = url + tmp.Name()
 		NewValue(reporter, data).Schema(url).
 			chain.assert(t, success)
 	})
@@ -1245,7 +1250,11 @@ func TestValue_Schema(t *testing.T) {
 		err = tmp.Close()
 		require.Nil(t, err)
 
-		url := "file://" + tmp.Name()
+		url := "file://"
+		if runtime.GOOS == "windows" {
+			url = url + "/"
+		}
+		url = url + tmp.Name()
 		NewValue(reporter, data).Schema(url).
 			chain.assert(t, failure)
 	})

--- a/value_test.go
+++ b/value_test.go
@@ -2,7 +2,6 @@ package httpexpect
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -1216,7 +1215,7 @@ func TestValue_Schema(t *testing.T) {
 			"foo": "a",
 			"bar": 1,
 		}
-		tmp, _ := ioutil.TempFile("", "httpexpect")
+		tmp, _ := os.CreateTemp("", "httpexpect")
 		defer os.Remove(tmp.Name())
 
 		_, err := tmp.Write([]byte(schema))
@@ -1241,7 +1240,7 @@ func TestValue_Schema(t *testing.T) {
 			"bar": "b",
 		}
 
-		tmp, _ := ioutil.TempFile("", "httpexpect")
+		tmp, _ := os.CreateTemp("", "httpexpect")
 		defer os.Remove(tmp.Name())
 
 		_, err := tmp.Write([]byte(schema))


### PR DESCRIPTION
PR for #413 

- added windows and macos in github actions for build, test and examples
- also replaced ioutil (deprecated since Go 1.16)
- Go version moved to 1.x for tests since some dependencies required Go >= 1.20