### PR TITLE
Bump golangci-lint version and fix new warnings (closes #424)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,7 +119,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         timeout-minutes: 20
         with:
-          version: v1.51.2
+          version: v1.54.2
           working-directory: ${{ matrix.dir }}
           args: --timeout=20m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,10 @@ linters:
 linters-settings:
   lll:
     line-length: 90
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Ah, GitHub isn't looking into the MR title. Okay, here's a tag for them: #424