### PR TITLE
Allow WithPath to work for floating point numbers

### DIFF
--- a/request.go
+++ b/request.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1049,7 +1050,13 @@ func (r *Request) withPath(opChain *chain, key string, value interface{}) {
 					},
 				})
 			} else {
-				mustWrite(w, fmt.Sprint(value))
+				switch value.(type) {
+				case float64, float32:
+					v := value.(float64)
+					mustWrite(w, strconv.FormatFloat(v, 'f', -1, 64))
+				default:
+					mustWrite(w, fmt.Sprint(value))
+				}
 				found = true
 			}
 		} else {

--- a/request_test.go
+++ b/request_test.go
@@ -1074,6 +1074,24 @@ func TestRequest_Path(t *testing.T) {
 		req.WithPath("arg", nil)
 		req.chain.assert(t, failure)
 	})
+
+	t.Run("floating point", func(t *testing.T) {
+		req := NewRequestC(config, "GET", "/{arg1}")
+		req.WithPath("arg1", 12345.6789)
+		req.Expect().chain.assert(t, success)
+		require.NotNil(t, client.req)
+		assert.Equal(t, "http://example.com/12345.6789",
+			client.req.URL.String())
+	})
+
+	t.Run("floating point with trailing zero", func(t *testing.T) {
+		req := NewRequestC(config, "GET", "/{arg1}")
+		req.WithPath("arg1", 12345.0)
+		req.Expect().chain.assert(t, success)
+		require.NotNil(t, client.req)
+		assert.Equal(t, "http://example.com/12345",
+			client.req.URL.String())
+	})
 }
 
 func TestRequest_PathObject(t *testing.T) {


### PR DESCRIPTION
#449 details the problem. The fix was to handle the cases of `float32` and `float64` separately, and use `strconv.FormatFloat` instead of `fmt.Sprint` in those cases.

I've also added a couple of test cases to verify it works and doesn't break this for other types.