### PR TITLE
Update broken link for golangci-lint installation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -46,7 +46,7 @@ Please follow a few simple rules to ease the work of the reviewer:
 
 For development, you need two additional dependencies:
 
-* [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+* [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
 
 * [stringer](https://github.com/golang/tools)
 


### PR DESCRIPTION
Fixed #451, i.e. changed the `golangci-lint` installation link to an updated one that isn't broken.