### PR TITLE
fix: preserve query from RequestFactory

### DIFF
--- a/request.go
+++ b/request.go
@@ -208,6 +208,10 @@ func (r *Request) initReq(opChain *chain, method string) {
 	}
 
 	r.httpReq = httpReq
+	if httpReq != nil && httpReq.URL != nil && httpReq.URL.RawQuery != "" {
+		query, _ := url.ParseQuery(httpReq.URL.RawQuery)
+		r.query = query
+	}
 }
 
 // Alias is similar to Value.Alias.


### PR DESCRIPTION
`httpexpect.Request` holds a copy of query in `r.query`, but fails to copy/sync the query set in the RequestFactory.